### PR TITLE
Style/reading calendar 독서 달력 스타일 수정

### DIFF
--- a/app/mypage/_components/CustomReadingCalendar.css
+++ b/app/mypage/_components/CustomReadingCalendar.css
@@ -1,30 +1,70 @@
 .react-calendar {
-  width: 592px;
-  height: 541px;
-  padding: 1rem;
+  width: 600px;
+  height: 680px;
+  padding: 15px;
   border: 1px solid #d9d9d9;
 }
 .react-calendar__navigation {
+  width: 255px;
   display: flex;
   height: 44px;
-  margin-bottom: 1em;
+  margin-left: 10px;
+  margin-bottom: 20px;
 }
 .react-calendar__navigation__label {
+  font-size: 26px;
+}
+.react-calendar__navigation__prev-button,
+.react-calendar__navigation__next-button {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid;
+  border-radius: 50%;
+}
+.react-calendar__navigation__label {
+  width: 133px;
   font-weight: 600;
 }
 .react-calendar__month-view__weekdays {
+  width: 100%;
+  height: 17px;
   text-align: center;
-  font-weight: 600;
+  font-size: 14px;
+  color: rgba(0, 0, 0, 0.5);
+  margin-bottom: 12px;
 }
 .react-calendar__month-view__weekdays abbr {
   text-decoration: none;
 }
+.react-calendar__month-view__days {
+  width: 568px;
+}
 .react-calendar__month-view__days button {
   position: relative;
-  width: 69.71px;
-  height: 66.33px;
+  width: 70.86px;
+  height: 102.2px;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 12px;
 }
 .react-calendar__month-view__days__day abbr {
   position: relative;
   z-index: 1;
+}
+.react-calendar__navigation__today-button {
+  border: 1px solid;
+  width: 60px;
+  height: 40px;
+}
+.react-calendar__navigation__today-button {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 60px;
+  height: 40px;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
 }

--- a/app/mypage/_components/CustomReadingCalendar.css
+++ b/app/mypage/_components/CustomReadingCalendar.css
@@ -68,3 +68,10 @@
   border: 1px solid #d9d9d9;
   border-radius: 4px;
 }
+.today-tile {
+  background-color: black;
+  border: 1px solid black;
+  color: white;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}

--- a/app/mypage/_components/CustomReadingCalendar.css
+++ b/app/mypage/_components/CustomReadingCalendar.css
@@ -68,6 +68,25 @@
   border: 1px solid #d9d9d9;
   border-radius: 4px;
 }
+.book-cover {
+  position: absolute;
+  bottom: 0;
+  left: 1/6;
+  border: 3px solid white;
+}
+.book-count {
+  position: absolute;
+  bottom: 0;
+  right: 4px;
+  width: 23px;
+  height: 16px;
+  font-size: 10px;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+  padding: 1px 5px;
+  background-color: white;
+  color: black;
+}
 .today-tile {
   background-color: black;
   border: 1px solid black;

--- a/app/mypage/_components/MyReadingCalendar.tsx
+++ b/app/mypage/_components/MyReadingCalendar.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import Calendar from 'react-calendar';
+import NextIcon from '../_svg/NextIcon';
+import PrevIcon from '../_svg/PrevIcon';
 import './CustomReadingCalendar.css';
 import { formatDate } from 'date-fns';
 import Image from 'next/image';
@@ -43,14 +45,21 @@ export default function MyReadingCalendar() {
     ) : null;
   };
   return (
-    <Calendar
-      locale='en'
-      view='month'
-      formatMonthYear={(locale, date) => formatDate(date, 'MMM yyyy')}
-      prev2Label={null}
-      next2Label={null}
-      showNeighboringMonth={false}
-      tileContent={getBookCover}
-    />
+    <div className='relative'>
+      <Calendar
+        locale='ko'
+        view='month'
+        formatMonthYear={(locale, date) => formatDate(date, 'yyyy년 M월')}
+        formatDay={(locale, date) => formatDate(date, 'd')}
+        prevLabel={<PrevIcon />}
+        nextLabel={<NextIcon />}
+        prev2Label={null}
+        next2Label={null}
+        calendarType='hebrew'
+        showNeighboringMonth={false}
+        tileContent={getBookCover}
+      />
+      <button className='react-calendar__navigation__today-button'>오늘</button>
+    </div>
   );
 }

--- a/app/mypage/_components/MyReadingCalendar.tsx
+++ b/app/mypage/_components/MyReadingCalendar.tsx
@@ -5,7 +5,7 @@ import Calendar from 'react-calendar';
 import NextIcon from '../_svg/NextIcon';
 import PrevIcon from '../_svg/PrevIcon';
 import './CustomReadingCalendar.css';
-import { formatDate } from 'date-fns';
+import { format, isToday } from 'date-fns';
 import Image from 'next/image';
 
 export default function MyReadingCalendar() {
@@ -42,14 +42,12 @@ export default function MyReadingCalendar() {
       <>
         <Image
           src={data.bookCover}
-          className='absolute bottom-0 left-1/6 border-[3px] border-white'
+          className='book-cover'
           alt={data.title}
           width={60}
           height={85}
         />
-        <span className='absolute bottom-0 right-[4px] w-[23px] h-[16px] text-[10px] border rounded px-[5px] py-[1px] bg-white text-black'>
-          +1
-        </span>
+        <span className='book-count'>+1</span>
       </>
     ) : null;
   };
@@ -58,19 +56,15 @@ export default function MyReadingCalendar() {
       <Calendar
         locale='ko'
         view='month'
-        formatMonthYear={(locale, date) => formatDate(date, 'yyyy년 M월')}
-        formatDay={(locale, date) => formatDate(date, 'd')}
+        formatMonthYear={(locale, date) => format(date, 'yyyy년 M월')}
+        formatDay={(locale, date) => format(date, 'd')}
         prevLabel={<PrevIcon />}
         nextLabel={<NextIcon />}
         prev2Label={null}
         next2Label={null}
         calendarType='hebrew'
         showNeighboringMonth={false}
-        tileClassName={({ date }) =>
-          date.toDateString() === new Date().toDateString()
-            ? 'today-tile'
-            : null
-        }
+        tileClassName={({ date }) => (isToday(date) ? 'today-tile' : null)}
         tileContent={getBookCover}
         activeStartDate={activeStartDate}
         onActiveStartDateChange={({ activeStartDate }) =>

--- a/app/mypage/_components/MyReadingCalendar.tsx
+++ b/app/mypage/_components/MyReadingCalendar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Calendar from 'react-calendar';
 import NextIcon from '../_svg/NextIcon';
 import PrevIcon from '../_svg/PrevIcon';
@@ -8,6 +9,11 @@ import { formatDate } from 'date-fns';
 import Image from 'next/image';
 
 export default function MyReadingCalendar() {
+  const [activeStartDate, setActiveStartDate] = useState(new Date());
+  const goToThisMonth = () => {
+    const today = new Date();
+    setActiveStartDate(new Date(today.getFullYear(), today.getMonth(), 1));
+  };
   const books = [
     {
       date: '2024-12-05',
@@ -58,8 +64,17 @@ export default function MyReadingCalendar() {
         calendarType='hebrew'
         showNeighboringMonth={false}
         tileContent={getBookCover}
+        activeStartDate={activeStartDate}
+        onActiveStartDateChange={({ activeStartDate }) =>
+          setActiveStartDate(activeStartDate as Date)
+        }
       />
-      <button className='react-calendar__navigation__today-button'>오늘</button>
+      <button
+        className='react-calendar__navigation__today-button'
+        onClick={goToThisMonth}
+      >
+        오늘
+      </button>
     </div>
   );
 }

--- a/app/mypage/_components/MyReadingCalendar.tsx
+++ b/app/mypage/_components/MyReadingCalendar.tsx
@@ -39,15 +39,18 @@ export default function MyReadingCalendar() {
     const data = books.find((b) => b.date === formattedDate);
 
     return data ? (
-      <div className='absolute top-1/4 left-1/4'>
+      <>
         <Image
           src={data.bookCover}
-          className='z-0'
+          className='absolute bottom-0 left-1/6 border-[3px] border-white'
           alt={data.title}
-          width='50'
-          height='75'
+          width={60}
+          height={85}
         />
-      </div>
+        <span className='absolute bottom-0 right-[4px] w-[23px] h-[16px] text-[10px] border rounded px-[5px] py-[1px] bg-white text-black'>
+          +1
+        </span>
+      </>
     ) : null;
   };
   return (
@@ -63,6 +66,11 @@ export default function MyReadingCalendar() {
         next2Label={null}
         calendarType='hebrew'
         showNeighboringMonth={false}
+        tileClassName={({ date }) =>
+          date.toDateString() === new Date().toDateString()
+            ? 'today-tile'
+            : null
+        }
         tileContent={getBookCover}
         activeStartDate={activeStartDate}
         onActiveStartDateChange={({ activeStartDate }) =>

--- a/app/mypage/_svg/NextIcon.tsx
+++ b/app/mypage/_svg/NextIcon.tsx
@@ -1,0 +1,19 @@
+export default function NextIcon() {
+  return (
+    <svg
+      width='24'
+      height='24'
+      viewBox='0 0 24 24'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <path
+        d='M8.99988 17.9998L14.9999 11.9998L8.99988 5.99976'
+        stroke='black'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  );
+}

--- a/app/mypage/_svg/PrevIcon.tsx
+++ b/app/mypage/_svg/PrevIcon.tsx
@@ -1,0 +1,19 @@
+export default function PrevIcon() {
+  return (
+    <svg
+      width='24'
+      height='24'
+      viewBox='0 0 24 24'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <path
+        d='M15.0001 17.9998L9.00012 11.9998L15.0001 5.99976'
+        stroke='black'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
##  🧲 Pull Request

## #️⃣ 연관된 이슈

>  #27 

## 📝 작업 내용
> 독서 달력 오늘 버튼 추가 + 클릭 시 이번 달로 이동
> 독서 달력 오늘 날짜는 검정색 배경 및 흰색 글씨 적용
> 읽은 책 표지와 개수 표시

## 🔢 리뷰 요구사항 (선택)
> 

## 🖼️ 스크린샷 (선택)
><img src='https://github.com/user-attachments/assets/55427ab9-2bab-4038-92c2-d0d10f40b3b4' width='600'/>


