### PR TITLE
Feat/mypage-layout2 나의 모임 페이지 와이어프레임 기반 스타일 적용

### DIFF
--- a/app/mypage/_components/MyReadingCalendar.tsx
+++ b/app/mypage/_components/MyReadingCalendar.tsx
@@ -52,7 +52,7 @@ export default function MyReadingCalendar() {
     ) : null;
   };
   return (
-    <div className='relative'>
+    <div className='relative w-[600px]'>
       <Calendar
         locale='ko'
         view='month'

--- a/app/mypage/_components/Sidebar.tsx
+++ b/app/mypage/_components/Sidebar.tsx
@@ -5,47 +5,36 @@ import { useSelectedLayoutSegment } from 'next/navigation';
 
 export default function Sidebar() {
   const segment = useSelectedLayoutSegment();
+
   return (
-    <ul className='flex flex-col gap-4 w-[346px] h-[790px] border pt-5 pl-5 text-2xl'>
-      <li
-        className={`w-[289px] h-[57px] hover:bg-[#D9D9D9] p-3 ${segment ? '' : 'bg-[#A0A0A0]'}`}
-      >
-        <Link href='/mypage' className='font-semibold'>
+    <ul className='flex flex-col gap-10 w-[253px] h-[790px] border pl-[41px] pt-[33px] pr-6 text-xl'>
+      <li className='w-[188px] hover:bg-[#D9D9D9] hover:bg-opacity-30 p-3'>
+        <Link
+          href='/mypage'
+          className={`${segment ? '' : 'font-bold'} leading-normal`}
+        >
           마이페이지
         </Link>
       </li>
-      <h4
-        className={`w-[289px] h-[57px] p-3 font-semibold ${segment === 'meetings' || segment === 'bookmark' ? 'bg-[#A0A0A0]' : ''}`}
-      >
-        나의 모임
-      </h4>
-      <li className='ml-10'>
+      <li className='w-[188px] p-3 hover:bg-[#D9D9D9] hover:bg-opacity-30'>
         <Link
           href='/mypage/meetings'
-          className={`w-full ${segment === 'meetings' ? 'font-bold' : ''}`}
+          className={` ${segment === 'meetings' ? 'font-bold' : ''} leading-normal`}
         >
-          참여중인 모임
+          나의 모임
         </Link>
       </li>
-      <li className='ml-10'>
-        <Link
-          href='/mypage/bookmark'
-          className={`${segment === 'bookmark' ? 'font-bold' : ''}`}
-        >
-          찜한 모임
-        </Link>
-      </li>
-      <li
-        className={`w-[289px] h-[57px] hover:bg-[#D9D9D9] p-3 ${segment === 'reviews' ? 'bg-[#A0A0A0]' : ''}`}
-      >
+      <li className='w-[188px] hover:bg-[#D9D9D9] hover:bg-opacity-30 p-3'>
         <Link
           href='/mypage/reviews'
-          className='w-full font-semibold hover:bg-[#D9D9D9]'
+          className={`w-full ${segment === 'reviews' ? 'font-bold' : ''} leading-normal`}
         >
           나의 리뷰
         </Link>
       </li>
-      <li className='mt-[360px] font-semibold'>로그아웃</li>
+      <li className='w-[188px] opacity-50 hover:bg-[#D9D9D9] hover:bg-opacity-30 p-3 leading-normal cursor-pointer'>
+        로그아웃
+      </li>
     </ul>
   );
 }

--- a/app/mypage/_svg/Calendar.tsx
+++ b/app/mypage/_svg/Calendar.tsx
@@ -1,0 +1,42 @@
+type Props = { width: number; height: number };
+
+export default function Calendar({ width, height }: Props) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox='0 0 16 16'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <path
+        d='M12.6667 2.66675H3.33333C2.59695 2.66675 2 3.2637 2 4.00008V13.3334C2 14.0698 2.59695 14.6667 3.33333 14.6667H12.6667C13.403 14.6667 14 14.0698 14 13.3334V4.00008C14 3.2637 13.403 2.66675 12.6667 2.66675Z'
+        stroke='black'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <path
+        d='M10.6667 1.33325V3.99992'
+        stroke='black'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <path
+        d='M5.33325 1.33325V3.99992'
+        stroke='black'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <path
+        d='M2 6.66675H14'
+        stroke='black'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  );
+}

--- a/app/mypage/_svg/Users.tsx
+++ b/app/mypage/_svg/Users.tsx
@@ -1,0 +1,54 @@
+type Props = { width: number; height: number };
+
+export default function Users({ width, height }: Props) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox='0 0 16 17'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <g clipPath='url(#clip0_340_1666)'>
+        <path
+          d='M11.004 14.3255V13.0309C11.004 12.3442 10.7312 11.6856 10.2457 11.2C9.76007 10.7144 9.10148 10.4417 8.41477 10.4417H3.23624C2.54952 10.4417 1.89093 10.7144 1.40535 11.2C0.919769 11.6856 0.646973 12.3442 0.646973 13.0309V14.3255'
+          stroke='black'
+          strokeWidth='1.29463'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+        />
+        <path
+          d='M5.82608 7.85211C7.25609 7.85211 8.41535 6.69286 8.41535 5.26285C8.41535 3.83284 7.25609 2.67358 5.82608 2.67358C4.39607 2.67358 3.23682 3.83284 3.23682 5.26285C3.23682 6.69286 4.39607 7.85211 5.82608 7.85211Z'
+          stroke='black'
+          strokeWidth='1.29463'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+        />
+        <path
+          d='M14.8887 14.3246V13.03C14.8883 12.4563 14.6974 11.899 14.3459 11.4456C13.9944 10.9922 13.5023 10.6683 12.9468 10.5249'
+          stroke='black'
+          strokeWidth='1.29463'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+        />
+        <path
+          d='M10.3569 2.75854C10.9139 2.90115 11.4076 3.22507 11.7601 3.67923C12.1126 4.13339 12.304 4.69197 12.304 5.26689C12.304 5.84182 12.1126 6.4004 11.7601 6.85456C11.4076 7.30872 10.9139 7.63264 10.3569 7.77524'
+          stroke='black'
+          strokeWidth='1.29463'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+        />
+      </g>
+      <defs>
+        <clipPath id='clip0_340_1666'>
+          <rect
+            width='15.5356'
+            height='15.5356'
+            fill='white'
+            transform='translate(0 0.732178)'
+          />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}

--- a/app/mypage/bookmark/page.tsx
+++ b/app/mypage/bookmark/page.tsx
@@ -1,3 +1,0 @@
-export default function BookmarkPage() {
-  return <div>찜한 모임 페이지</div>;
-}

--- a/app/mypage/layout.tsx
+++ b/app/mypage/layout.tsx
@@ -5,7 +5,7 @@ type Props = { children: React.ReactNode };
 export default function MypageLayout({ children }: Props) {
   return (
     <div className='flex flex-col items-center mt-24'>
-      <div className='flex items-center gap-5'>
+      <div className='flex items-center gap-20'>
         <aside>
           <Sidebar />
         </aside>

--- a/app/mypage/meetings/_components/Meeting.tsx
+++ b/app/mypage/meetings/_components/Meeting.tsx
@@ -1,0 +1,40 @@
+import Calendar from '../../_svg/Calendar';
+import Users from '../../_svg/Users';
+import type { Meeting } from '@/types/meeting';
+
+export default function Meeting({ meeting }: { meeting: Meeting }) {
+  const { name, gathering_date, end_date, capacity } = meeting;
+  return (
+    <div className='px-[14px] py-[18px] border border-[rgba(0, 0, 0, 0.10)] rounded-[8px]'>
+      <div className='flex gap-5'>
+        <div className='w-[131px] h-[165px] bg-[#D9D9D9]'>모임 이미지</div>
+        <div className='flex flex-col gap-2.5 flex-1'>
+          <div className='flex items-center justify-between'>
+            <h3 className='text-lg font-bold'>{name}</h3>
+            <div className='flex gap-1.5 w-44 h-8 px-2.5 py-1.5 text-sm bg-[#E4E4E4] rounded'>
+              <Users width={16} height={17} />
+              {capacity}명과 함께 읽는 중
+            </div>
+          </div>
+          <p>모임 기간</p>
+          <div className='flex gap-2 font-bold'>
+            <Calendar width={16} height={16} />
+            {gathering_date.toLocaleDateString('ko', {
+              month: '2-digit',
+              day: '2-digit',
+              weekday: 'short',
+            })}{' '}
+            -{' '}
+            {end_date.toLocaleDateString('ko', {
+              month: '2-digit',
+              day: '2-digit',
+              weekday: 'short',
+            })}
+          </div>
+          <p>참여율</p>
+          <div className='w-[200px] h-[15px] bg-[#D9D9D9] rounded-[8px]'></div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/mypage/meetings/_components/Meetings.tsx
+++ b/app/mypage/meetings/_components/Meetings.tsx
@@ -1,0 +1,31 @@
+import Meeting from './Meeting';
+
+export default function Meetings() {
+  const meetings = [
+    {
+      name: '모임 1',
+      gathering_date: new Date(2024, 11, 10),
+      end_date: new Date(2024, 11, 24),
+      capacity: 31,
+    },
+    {
+      name: '모임 2',
+      gathering_date: new Date(2024, 11, 20),
+      end_date: new Date(2024, 11, 31),
+      capacity: 15,
+    },
+    {
+      name: '모임 3',
+      gathering_date: new Date(2025, 0, 8),
+      end_date: new Date(2025, 0, 24),
+      capacity: 4,
+    },
+  ];
+  return (
+    <div className='flex flex-col gap-[15px] mt-[34px]'>
+      {meetings.map((meeting, i) => (
+        <Meeting key={i} meeting={meeting} />
+      ))}
+    </div>
+  );
+}

--- a/app/mypage/meetings/_components/Tab.tsx
+++ b/app/mypage/meetings/_components/Tab.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useTabContext } from './TabContext';
+
+export default function Tab() {
+  const { tab, setTab } = useTabContext();
+
+  return (
+    <div className='flex gap-[34px] text-xl border-b h-12'>
+      <div
+        className={`cursor-pointer ${tab === 'active' ? 'border-b-4 border-black' : ''}`}
+        onClick={() => setTab('active')}
+      >
+        참여 중인 모임
+        <span className='ml-[3px] px-2 bg-black text-white rounded-[30px] text-xl'>
+          3
+        </span>
+      </div>
+      <div
+        className={`cursor-pointer ${tab === 'completed' ? 'border-b-4 border-black' : ''}`}
+        onClick={() => setTab('completed')}
+      >
+        완료한 모임
+        <span className='ml-[3px] px-2 bg-black text-white rounded-[30px] text-xl'>
+          3
+        </span>
+      </div>
+      <div
+        className={`cursor-pointer ${tab === 'created' ? 'border-b-4 border-black' : ''}`}
+        onClick={() => setTab('created')}
+      >
+        내가 만든 모임
+        <span className='ml-[3px] px-2 bg-black text-white rounded-[30px] text-xl'>
+          3
+        </span>
+      </div>
+      <div
+        className={`cursor-pointer ${tab === 'bookmark' ? 'border-b-4 border-black' : ''}`}
+        onClick={() => setTab('bookmark')}
+      >
+        찜한 모임
+        <span className='ml-[3px] px-2 bg-black text-white rounded-[30px] text-xl'>
+          3
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/app/mypage/meetings/_components/Tab.tsx
+++ b/app/mypage/meetings/_components/Tab.tsx
@@ -4,7 +4,6 @@ import { useTabContext } from './TabContext';
 
 export default function Tab() {
   const { tab, setTab } = useTabContext();
-  console.log('tab', tab);
   const tabs = [
     { value: 'active', label: '참여 중인 모임', count: 3 },
     { value: 'completed', label: '완료한 모임', count: 3 },

--- a/app/mypage/meetings/_components/Tab.tsx
+++ b/app/mypage/meetings/_components/Tab.tsx
@@ -4,45 +4,28 @@ import { useTabContext } from './TabContext';
 
 export default function Tab() {
   const { tab, setTab } = useTabContext();
+  console.log('tab', tab);
+  const tabs = [
+    { value: 'active', label: '참여 중인 모임', count: 3 },
+    { value: 'completed', label: '완료한 모임', count: 3 },
+    { value: 'created', label: '내가 만든 모임', count: 3 },
+    { value: 'bookmark', label: '찜한 모임', count: 3 },
+  ] as const;
 
   return (
     <div className='flex gap-[34px] text-xl border-b h-12'>
-      <div
-        className={`cursor-pointer ${tab === 'active' ? 'border-b-4 border-black' : ''}`}
-        onClick={() => setTab('active')}
-      >
-        참여 중인 모임
-        <span className='ml-[3px] px-2 bg-black text-white rounded-[30px] text-xl'>
-          3
-        </span>
-      </div>
-      <div
-        className={`cursor-pointer ${tab === 'completed' ? 'border-b-4 border-black' : ''}`}
-        onClick={() => setTab('completed')}
-      >
-        완료한 모임
-        <span className='ml-[3px] px-2 bg-black text-white rounded-[30px] text-xl'>
-          3
-        </span>
-      </div>
-      <div
-        className={`cursor-pointer ${tab === 'created' ? 'border-b-4 border-black' : ''}`}
-        onClick={() => setTab('created')}
-      >
-        내가 만든 모임
-        <span className='ml-[3px] px-2 bg-black text-white rounded-[30px] text-xl'>
-          3
-        </span>
-      </div>
-      <div
-        className={`cursor-pointer ${tab === 'bookmark' ? 'border-b-4 border-black' : ''}`}
-        onClick={() => setTab('bookmark')}
-      >
-        찜한 모임
-        <span className='ml-[3px] px-2 bg-black text-white rounded-[30px] text-xl'>
-          3
-        </span>
-      </div>
+      {tabs.map(({ value, label, count }) => (
+        <div
+          key={value}
+          className={`cursor-pointer ${tab === value ? 'border-b-4 border-black' : ''}`}
+          onClick={() => setTab(value)}
+        >
+          {label}
+          <span className='ml-[3px] px-2 bg-black text-white rounded-[30px] text-xl'>
+            {count}
+          </span>
+        </div>
+      ))}
     </div>
   );
 }

--- a/app/mypage/meetings/_components/TabContext.tsx
+++ b/app/mypage/meetings/_components/TabContext.tsx
@@ -8,7 +8,7 @@ type TabContextType = {
 };
 
 export const TabContext = createContext<TabContextType | null>(null);
-export default function MeetingTabContextProvider({
+export default function TabContextProvider({
   children,
 }: {
   children: React.ReactNode;

--- a/app/mypage/meetings/_components/TabContext.tsx
+++ b/app/mypage/meetings/_components/TabContext.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { createContext, useContext, useState } from 'react';
+
+type TabContextType = {
+  tab: 'active' | 'completed' | 'created' | 'bookmark';
+  setTab: (value: 'active' | 'completed' | 'created' | 'bookmark') => void;
+};
+
+export const TabContext = createContext<TabContextType | null>(null);
+export default function MeetingTabContextProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [tab, setTab] = useState<TabContextType['tab']>('active');
+  return (
+    <TabContext.Provider value={{ tab, setTab }}>
+      {children}
+    </TabContext.Provider>
+  );
+}
+export const useTabContext = () => {
+  const context = useContext(TabContext);
+  if (!context) {
+    throw new Error('useTabContext must be used within TabProvider');
+  }
+  return context;
+};

--- a/app/mypage/meetings/page.tsx
+++ b/app/mypage/meetings/page.tsx
@@ -1,3 +1,4 @@
+import Meetings from './_components/Meetings';
 import Tab from './_components/Tab';
 import TabProvider from './_components/TabContext';
 
@@ -7,6 +8,7 @@ export default function MyMeetingPage() {
       <h3 className='text-xl font-bold mb-[15px]'>나의 모임</h3>
       <TabProvider>
         <Tab />
+        <Meetings />
       </TabProvider>
     </div>
   );

--- a/app/mypage/meetings/page.tsx
+++ b/app/mypage/meetings/page.tsx
@@ -3,7 +3,7 @@ import TabProvider from './_components/TabContext';
 
 export default function MyMeetingPage() {
   return (
-    <div>
+    <div className='w-[750px] p-5'>
       <h3 className='text-xl font-bold mb-[15px]'>나의 모임</h3>
       <TabProvider>
         <Tab />

--- a/app/mypage/meetings/page.tsx
+++ b/app/mypage/meetings/page.tsx
@@ -1,3 +1,13 @@
+import Tab from './_components/Tab';
+import TabProvider from './_components/TabContext';
+
 export default function MyMeetingPage() {
-  return <div>참여중인 모임 페이지</div>;
+  return (
+    <div>
+      <h3 className='text-xl font-bold mb-[15px]'>나의 모임</h3>
+      <TabProvider>
+        <Tab />
+      </TabProvider>
+    </div>
+  );
 }

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -3,11 +3,11 @@ import Profile from './_components/Profile';
 
 export default function MyPage() {
   return (
-    <>
+    <div className='w-[750px] p-5'>
       <h3 className='text-[32px] font-semibold my-2'>마이페이지</h3>
       <Profile />
       <h4 className='text-xl font-bold mb-5'>나의 독서 달력</h4>
       <MyReadingCalendar />
-    </>
+    </div>
   );
 }

--- a/app/mypage/reviews/page.tsx
+++ b/app/mypage/reviews/page.tsx
@@ -1,3 +1,3 @@
 export default function MyReviewPage() {
-  return <div>나의 리뷰 페이지</div>;
+  return <div className='w-[750px] p-5'>나의 리뷰 페이지</div>;
 }

--- a/types/meeting.ts
+++ b/types/meeting.ts
@@ -1,0 +1,6 @@
+export type Meeting = {
+  name: string;
+  gathering_date: Date;
+  end_date: Date;
+  capacity: number;
+};


### PR DESCRIPTION
##  🧲 Pull Request

## #️⃣ 연관된 이슈

> #33 

## 📝 작업 내용
 마이 페이지 내 사이드 바는 '나의 모임' 링크로 통합했습니다. 나의 모임 페이지 내에서 탭 컴포넌트를 만들어 context api로 상태 값이 변경될 때 마다 border를 주는 효과를 주었습니다. 
현재 나의 모임 페이지는 와이어프레임 기반으로 스타일을 적용했습니다. 

## 🔢 리뷰 요구사항 (선택)
  feat/mypage-meetings-layout 브랜치에서 pr 올리면 다른 사람 커밋까지 올라가는 문제가 생겨서 따로 브랜치 파서 pr 올립니다! 

## 🖼️ 스크린샷 (선택)
><img src='https://github.com/user-attachments/assets/ccccfeac-9850-4aba-96ea-a85d302891d0' width='600'/><p>탭 컴포넌트 상태 값 변경 시 border 추가 </p>
><img src='https://github.com/user-attachments/assets/996352b4-4ef8-4b94-a445-02fc2821965b' width='600'/>
<p>나의 모임 페이지</p>



