### PR TITLE
Style/signup 회원가입 페이지 UI 변경

### DIFF
--- a/app/auth/_components/form-button.tsx
+++ b/app/auth/_components/form-button.tsx
@@ -6,13 +6,18 @@ import { Button } from '@/components/ui/button';
 interface FormButtonProps {
   children: React.ReactNode;
   disabled: boolean;
+  className?: string;
 }
 
-export const FormButton = ({ children, disabled }: FormButtonProps) => {
+export const FormButton = ({
+  className,
+  children,
+  disabled,
+}: FormButtonProps) => {
   const { pending } = useFormStatus();
 
   return (
-    <Button type='submit' disabled={disabled || pending}>
+    <Button className={className} type='submit' disabled={disabled || pending}>
       {children}
     </Button>
   );

--- a/app/auth/_components/form-input-field.tsx
+++ b/app/auth/_components/form-input-field.tsx
@@ -20,9 +20,9 @@ export const FormInputField = ({
   disabled,
   onChange,
 }: FormInputFieldProps) => (
-  <div>
+  <div className='flex flex-col gap-2'>
     <Input
-      className='w-[380px] h-11 px-2.5 py-1.5'
+      className='w-[380px] h-11 px-2.5 py-1.5 focus-visible:ring-transparent'
       id={id}
       name={name}
       type={type}
@@ -34,7 +34,7 @@ export const FormInputField = ({
     {errors && (
       <div>
         {errors.map((error: string) => (
-          <p key={error} className='text-rose-500'>
+          <p key={error} className='text-error'>
             {error}
           </p>
         ))}

--- a/app/auth/_components/form-input-field.tsx
+++ b/app/auth/_components/form-input-field.tsx
@@ -22,6 +22,7 @@ export const FormInputField = ({
 }: FormInputFieldProps) => (
   <div>
     <Input
+      className='w-[380px] h-11 px-2.5 py-1.5'
       id={id}
       name={name}
       type={type}

--- a/app/auth/_svg/CheckIcon.tsx
+++ b/app/auth/_svg/CheckIcon.tsx
@@ -1,0 +1,20 @@
+export default function CheckIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      {...props}
+      xmlns='http://www.w3.org/2000/svg'
+      width='20'
+      height='20'
+      viewBox='0 0 20 20'
+      fill='none'
+    >
+      <path
+        d='M16.6666 5L7.49998 14.1667L3.33331 10'
+        stroke='black'
+        strokeWidth='1.58854'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  );
+}

--- a/app/auth/_svg/EyeIcon.tsx
+++ b/app/auth/_svg/EyeIcon.tsx
@@ -11,16 +11,16 @@ const EyeIcon: React.FC<SVGProps<SVGSVGElement>> = (props) => {
       <path
         d='M1 12C1 12 5 5 12 5C19 5 23 12 23 12C23 12 19 19 12 19C5 19 1 12 1 12Z'
         stroke='#A9A9A9'
-        stroke-width='1.5'
-        stroke-linecap='round'
-        stroke-linejoin='round'
+        strokeWidth='1.5'
+        strokeLinecap='round'
+        strokeLinejoin='round'
       />
       <path
         d='M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z'
         fill='#A9A9A9'
         stroke='#A9A9A9'
-        stroke-linecap='round'
-        stroke-linejoin='round'
+        strokeLinecap='round'
+        strokeLinejoin='round'
       />
     </svg>
   );

--- a/app/auth/_svg/EyeIcon.tsx
+++ b/app/auth/_svg/EyeIcon.tsx
@@ -6,13 +6,22 @@ const EyeIcon: React.FC<SVGProps<SVGSVGElement>> = (props) => {
       {...props}
       viewBox='0 0 24 24'
       fill='none'
-      stroke='currentColor'
-      strokeWidth='2'
-      strokeLinecap='round'
-      strokeLinejoin='round'
+      xmlns='http://www.w3.org/2000/svg'
     >
-      <path d='M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z' />
-      <circle cx='12' cy='12' r='3' />
+      <path
+        d='M1 12C1 12 5 5 12 5C19 5 23 12 23 12C23 12 19 19 12 19C5 19 1 12 1 12Z'
+        stroke='#A9A9A9'
+        stroke-width='1.5'
+        stroke-linecap='round'
+        stroke-linejoin='round'
+      />
+      <path
+        d='M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z'
+        fill='#A9A9A9'
+        stroke='#A9A9A9'
+        stroke-linecap='round'
+        stroke-linejoin='round'
+      />
     </svg>
   );
 };

--- a/app/auth/signup/_components/TermsAgreement.tsx
+++ b/app/auth/signup/_components/TermsAgreement.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import CheckIcon from '@/app/auth/_svg/CheckIcon';
+import { Checkbox } from '@/components/ui/checkbox';
+import { CheckedState } from '@radix-ui/react-checkbox';
+
+type Terms = {
+  all: CheckedState;
+  age: boolean;
+  service: boolean;
+  privacy: boolean;
+};
+type Props = {
+  setIsTermsAgreed: (isAgreed: boolean) => void;
+};
+export default function TermsAgreement({ setIsTermsAgreed }: Props) {
+  const [terms, setTerms] = useState<Terms>({
+    all: 'indeterminate',
+    age: false,
+    service: false,
+    privacy: false,
+  });
+
+  const handleAllCheck = (isCheked: boolean) => {
+    setTerms({
+      all: isCheked,
+      age: isCheked,
+      service: isCheked,
+      privacy: isCheked,
+    });
+    setIsTermsAgreed(isCheked);
+  };
+  const handleIndividualCheck = (key: keyof Omit<Terms, 'all'>) => {
+    const isChecked = terms[key];
+    const updated = { ...terms, [key]: !isChecked };
+    setTerms(updated);
+
+    const isAllChecked = updated.age && updated.service && updated.privacy;
+    if (isAllChecked) {
+      setTerms({ ...updated, all: isAllChecked });
+      setIsTermsAgreed(true);
+    } else {
+      setIsTermsAgreed(false);
+    }
+  };
+
+  return (
+    <div className='flex flex-col gap-[18px] mt-[18px] my-[90px]'>
+      <p className='text-lg font-bold'>약관동의</p>
+      <div className='items-top flex space-x-2 border p-[18px] rounded'>
+        <Checkbox
+          id='terms'
+          checked={terms.all}
+          onCheckedChange={(isChecked) => handleAllCheck(isChecked as boolean)}
+          className='w-5 h-5 rounded-full text-gray-200'
+        />
+        <div className='grid gap-1.5 leading-none'>
+          <label
+            htmlFor='terms'
+            className='text-sm font-bold leading-none cursor-pointer peer-disabled:opacity-70'
+          >
+            전체 동의하기
+          </label>
+          <p className='text-xs text-[#828282]'>
+            서비스 이용을 위한 필수 약관에 동의합니다.
+          </p>
+        </div>
+      </div>
+      <div className='flex flex-col gap-[18px] text-xs'>
+        <div className='flex gap-2'>
+          <span className='w-5 h-5 flex items-center justify-center'>
+            <CheckIcon
+              className={`${terms.age ? 'opacity-100' : 'opacity-0'}`}
+            />
+          </span>
+          <p
+            className='color[#111827] cursor-pointer'
+            onClick={() => handleIndividualCheck('age')}
+          >
+            (필수) 만 14세 이상입니다.
+          </p>
+        </div>
+        <div className='flex gap-2'>
+          <CheckIcon
+            className={`${terms.service ? 'opacity-100' : 'opacity-0'}`}
+          />
+          <p
+            className='flex-1 flex justify-between color-[#111827] cursor-pointer'
+            onClick={() => handleIndividualCheck('service')}
+          >
+            (필수) 서비스 이용약관
+            <span className='underline'>자세히</span>
+          </p>
+        </div>
+        <div className='flex gap-2'>
+          <CheckIcon
+            className={`${terms.privacy ? 'opacity-100' : 'opacity-0'}`}
+          />
+          <p
+            className='flex-1 flex justify-between  color-[#111827] cursor-pointer'
+            onClick={() => handleIndividualCheck('privacy')}
+          >
+            (필수) 개인정보 수집 및 이용동의
+            <span className='underline'>자세히</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/auth/signup/_components/signup-form-duplicateCheckButton.tsx
+++ b/app/auth/signup/_components/signup-form-duplicateCheckButton.tsx
@@ -36,7 +36,7 @@ export const CheckDuplicateButton = ({
     if (result.isDuplicate) {
       setError([result.message]);
       setStatusMessage(result.message);
-      setMessageColor('text-red-500');
+      setMessageColor('text-error');
       onFailure();
     } else {
       setError([]);
@@ -47,17 +47,15 @@ export const CheckDuplicateButton = ({
   };
 
   return (
-    <div>
+    <div className='flex flex-col gap-2'>
       <Button
         onClick={handleCheck}
         type='button'
-        className='px-2 py-1 bg-black text-white rounded'
+        className='w-20 px-2 py-1 bg-black text-white rounded'
       >
         중복 검사
       </Button>
-      {statusMessage && (
-        <p className={`mt-1 ${messageColor}`}>{statusMessage}</p>
-      )}
+      {statusMessage && <p className={` ${messageColor}`}>{statusMessage}</p>}
     </div>
   );
 };

--- a/app/auth/signup/_components/signup-form-duplicateCheckButton.tsx
+++ b/app/auth/signup/_components/signup-form-duplicateCheckButton.tsx
@@ -51,7 +51,7 @@ export const CheckDuplicateButton = ({
       <Button
         onClick={handleCheck}
         type='button'
-        className='px-2 py-1 bg-blue-500 text-white rounded'
+        className='px-2 py-1 bg-black text-white rounded'
       >
         중복 검사
       </Button>

--- a/app/auth/signup/_components/signup-form-input.tsx
+++ b/app/auth/signup/_components/signup-form-input.tsx
@@ -31,69 +31,93 @@ export const SignupFormInput = ({
   };
 
   return (
-    <div>
-      <div className='flex items-center space-x-2'>
-        <FormInputField
-          id='userName'
-          name='userName'
-          type='text'
-          placeholder='이름을 입력하세요'
-          disabled={pending}
-          errors={errors?.userName || userNameError}
-          onChange={(e) => setUserName(e.target.value)}
-        />
-        <CheckDuplicateButton
-          type='userName'
-          value={userName}
-          setError={setUserNameError}
-          onSuccess={() => setIsUserNameValid(true)}
-          onFailure={() => setIsUserNameValid(false)}
-        />
+    <div className='flex flex-col gap-[30px]'>
+      <div>
+        <p className='text-lg font-bold mb-3'>이메일</p>
+        <div className='flex items-center space-x-2'>
+          <FormInputField
+            id='email'
+            name='email'
+            type='email'
+            placeholder='abc@email.com'
+            errors={errors?.email || emailError}
+            disabled={pending}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <CheckDuplicateButton
+            type='email'
+            value={email}
+            setError={setEmailError}
+            onSuccess={() => setIsEmailValid(true)}
+            onFailure={() => setIsEmailValid(false)}
+          />
+        </div>
       </div>
-      <div className='flex items-center space-x-2'>
-        <FormInputField
-          id='email'
-          name='email'
-          type='email'
-          placeholder='이메일을 입력하세요'
-          errors={errors?.email || emailError}
-          disabled={pending}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <CheckDuplicateButton
-          type='email'
-          value={email}
-          setError={setEmailError}
-          onSuccess={() => setIsEmailValid(true)}
-          onFailure={() => setIsEmailValid(false)}
-        />
+      <div>
+        <p className='text-lg font-bold mb-3'>비밀번호</p>
+        <div className='relative flex w-[380px]'>
+          <FormInputField
+            id='password'
+            name='password'
+            type={showPassword ? 'text' : 'password'}
+            placeholder='8자 이상의 비밀번호'
+            errors={errors?.password}
+            disabled={pending}
+          />
+          <button
+            className='absolute top-3 right-2.5'
+            onClick={togglePasswordVisibility}
+            type='button'
+          >
+            <EyeIcon
+              className={`transition-all duration-300 h-6 w-6 ${showPassword ? 'text-gray-700' : 'text-gray-400'}`}
+            />
+          </button>
+        </div>
       </div>
-      <FormInputField
-        id='password'
-        name='password'
-        type={showPassword ? 'text' : 'password'}
-        placeholder='비밀번호를 입력하세요'
-        errors={errors?.password}
-        disabled={pending}
-      />
-      <button onClick={togglePasswordVisibility} type='button'>
-        <EyeIcon
-          className={`transition-all duration-300 h-6 w-6 ${showPassword ? 'text-gray-700' : 'text-gray-400'}`}
-        />
-      </button>
-      <FormInputField
-        id='confirmPassword'
-        name='confirmPassword'
-        type={showPassword ? 'text' : 'password'}
-        placeholder='비밀번호를 다시 입력하세요'
-        errors={errors?.confirmPassword}
-        disabled={pending}
-      />
-      <button onClick={togglePasswordVisibility} type='button'>
-        <EyeIcon
-          className={`transition-all duration-300 h-6 w-6 ${showPassword ? 'text-gray-700' : 'text-gray-400'}`}
-        />
-      </button>
+      <div>
+        <p className='text-lg font-bold mb-3'>비밀번호 확인</p>
+        <div className='relative flex w-[380px]'>
+          <FormInputField
+            id='confirmPassword'
+            name='confirmPassword'
+            type={showPassword ? 'text' : 'password'}
+            placeholder='비밀번호를 다시 입력하세요'
+            errors={errors?.confirmPassword}
+            disabled={pending}
+          />
+          <button
+            className='absolute top-3 right-2.5'
+            onClick={togglePasswordVisibility}
+            type='button'
+          >
+            <EyeIcon
+              className={`transition-all duration-300 h-6 w-6 ${showPassword ? 'text-gray-700' : 'text-gray-400'}`}
+            />
+          </button>
+        </div>
+      </div>
+      <div>
+        <p className='text-lg font-bold mb-3'>닉네임</p>
+        <div className='flex items-center space-x-2 mb-[30px]'>
+          <FormInputField
+            id='userName'
+            name='userName'
+            type='text'
+            placeholder='10자 이내의 닉네임'
+            disabled={pending}
+            errors={errors?.userName || userNameError}
+            onChange={(e) => setUserName(e.target.value)}
+          />
+          <CheckDuplicateButton
+            type='userName'
+            value={userName}
+            setError={setUserNameError}
+            onSuccess={() => setIsUserNameValid(true)}
+            onFailure={() => setIsUserNameValid(false)}
+          />
+        </div>
+      </div>
     </div>
   );
 };

--- a/app/auth/signup/_components/signup-form-input.tsx
+++ b/app/auth/signup/_components/signup-form-input.tsx
@@ -34,7 +34,7 @@ export const SignupFormInput = ({
     <div className='flex flex-col gap-[30px]'>
       <div>
         <p className='text-lg font-bold mb-3'>이메일</p>
-        <div className='flex items-center space-x-2'>
+        <div className='flex space-x-2'>
           <FormInputField
             id='email'
             name='email'
@@ -99,7 +99,7 @@ export const SignupFormInput = ({
       </div>
       <div>
         <p className='text-lg font-bold mb-3'>닉네임</p>
-        <div className='flex items-center space-x-2 mb-[30px]'>
+        <div className='flex space-x-2 mb-[30px]'>
           <FormInputField
             id='userName'
             name='userName'

--- a/app/auth/signup/_components/signup-form.tsx
+++ b/app/auth/signup/_components/signup-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useFormState } from 'react-dom';
 import { userSignup } from '../_lib/signup';
+import TermsAgreement from './TermsAgreement';
 import { SignupFormInput } from './signup-form-input';
 import { FormButton } from '@/app/auth/_components/form-button';
 
@@ -11,8 +12,9 @@ export const SignupForm = () => {
   const [state, dispatch] = useFormState(userSignup, initialState);
   const [isEmailValid, setIsEmailValid] = useState(false);
   const [isUserNameValid, setIsUserNameValid] = useState(false);
+  const [isTermsAgreed, setIsTermsAgreed] = useState(false);
 
-  const isFormValid = isEmailValid && isUserNameValid;
+  const isFormValid = isEmailValid && isUserNameValid && isTermsAgreed;
 
   return (
     <form action={dispatch}>
@@ -23,7 +25,13 @@ export const SignupForm = () => {
           setIsUserNameValid={setIsUserNameValid}
         />
       </div>
-      <FormButton disabled={!isFormValid}>회원가입</FormButton>
+      <TermsAgreement setIsTermsAgreed={setIsTermsAgreed} />
+      <FormButton
+        className='w-full h-12 p-2.5 font-bold bg-black rounded'
+        disabled={!isFormValid}
+      >
+        가입하기
+      </FormButton>
       {state?.message}
     </form>
   );

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -2,8 +2,9 @@ import { SignupForm } from './_components/signup-form';
 
 export default function SignUpPage() {
   return (
-    <div>
-      <h2>회원가입 페이지</h2>
+    <div className='flex flex-col justify-center items-center mt-32'>
+      <p className='mb-2.5'>모여서 읽고 싶은 지금, 모읽지</p>
+      <h2 className='text-2xl font-bold mb-12'>회원가입</h2>
       <SignupForm />
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,10 +6,6 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
-li {
-  list-style: none;
-}
-
 @layer base {
   :root {
     --background: 0 0% 100%;
@@ -72,5 +68,11 @@ li {
   }
   body {
     @apply bg-background text-foreground;
+  }
+  input {
+    @apply outline-none;
+  }
+  li {
+    @apply list-none;
   }
 }

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
+import { Check } from 'lucide-react';
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      'peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      className,
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn('flex items-center justify-center text-current')}
+    >
+      <Check className='h-4 w-4' />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nexttemp",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-checkbox": "^1.1.3",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-slot": "^1.1.0",
@@ -992,6 +993,116 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.1.3.tgz",
+      "integrity": "sha512-HD7/ocp8f1B3e6OHygH0n7ZKjONkhciy1Nh0yuBgObqThc3oyx+vuMfFHKAknXRHHWVE9XvXStxJFyjUmB8PIw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA=="
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
+      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
+      "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "mock": "npx tsx watch ./mocks/http.ts"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.1.3",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -51,6 +51,7 @@ export default {
           '4': 'hsl(var(--chart-4))',
           '5': 'hsl(var(--chart-5))',
         },
+        error: '#DC2626',
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
##  🧲 Pull Request

## #️⃣ 연관된 이슈

> #50

## 📝 작업 내용
회원가입 페이지 UI 변경했습니다. 약관 동의가 있어서 shadcn/checkbox를 따로 설치해서 적용했습니다. 
전체 동의를 해야 회원가입 버튼을 누를 수 있으며 아래 3개 체크박스를 개별 해제도 가능합니다. 
현재 오류 메세지 같은 경우, API로부터 받는 메세지여서 아직 수정하지 못했습니다. 오류 메세지 색상만 변경하고 중복 검사  통과나 오류가 날 경우 레이아웃 배치가 안맞아서 일부만 변경했습니다.  

## 🔢 리뷰 요구사항 (선택)
>

## 🖼️ 스크린샷 (선택)
><img src='https://github.com/user-attachments/assets/f31eca2a-bc0f-4be3-ae2a-1d87b5befda4' width='400'/>
<p>회원가입 UI </p>
<img src='https://github.com/user-attachments/assets/47c6412a-035c-4986-9de3-89ed3aad666f' width='400'/>
<p>유효성 통과  시 UI </p>
<img src='https://github.com/user-attachments/assets/9cd4e361-0675-4754-aa0a-7151f8375d26' width='400'/>
<p>유효성 통과 실패 시 UI </p> 


