### PR TITLE
Feat/detailpage api header 모임 상세페이지 헤더파트 api연결 및 기능구현

### DIFF
--- a/app/_components/MainPageBody.tsx
+++ b/app/_components/MainPageBody.tsx
@@ -18,6 +18,7 @@ import SearchIcon from '@/public/SearchIcon';
 import UsersIcon from '@/public/UsersIcon';
 import { format } from 'date-fns';
 import Image from 'next/image';
+import Link from 'next/link';
 
 export default function MainPageBody() {
   const [meetingsData, setMeetingsData] = useState<IMeeting[]>([]);
@@ -220,54 +221,53 @@ export default function MainPageBody() {
           </div>
           <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
             {filteredMeetings.map((meeting) => (
-              <div
-                key={meeting.id}
-                className='h-[298px] border rounded-lg shadow-md hover:shadow-lg bg-white flex flex-col'
-              >
-                <div className='w-full h-[148px] flex justify-center items-center bg-[#D9D9D9]'>
-                  <Image
-                    src={meeting.thumbnail}
-                    alt='meeting-thumbnail-image'
-                    width={360}
-                    height={148}
-                    style={{ width: 360, height: 148 }}
-                  />
-                </div>
-                <div className='flex flex-row p-4'>
-                  <div className='w-[87.8px] h-[132px] -mt-10 mr-3 flex justify-center items-center'>
+              <Link href={`/meeting-detail/${meeting.id}}`} key={meeting.id}>
+                <div className='h-[298px] border rounded-lg shadow-md hover:shadow-lg bg-white flex flex-col'>
+                  <div className='w-full h-[148px] flex justify-center items-center bg-[#D9D9D9]'>
                     <Image
-                      src={meeting.bookImage}
-                      alt='meeting-bookcover-image'
+                      src={meeting.thumbnail}
+                      alt='meeting-thumbnail-image'
                       width={360}
                       height={148}
                       style={{ width: 360, height: 148 }}
                     />
                   </div>
-                  <div>
-                    <h3 className='text-lg font-semibold mb-3'>
-                      {meeting.name}
-                    </h3>
-                    <div className='flex flex-row gap-[2px]'>
-                      <UsersIcon width={16} height={16} />
-                      <p className='text-sm text-gray-600'>
-                        {meeting.currentCapacity}명 / {meeting.maxCapacity}명
-                      </p>
+                  <div className='flex flex-row p-4'>
+                    <div className='w-[87.8px] h-[132px] -mt-10 mr-3 flex justify-center items-center'>
+                      <Image
+                        src={meeting.bookImage}
+                        alt='meeting-bookcover-image'
+                        width={360}
+                        height={148}
+                        style={{ width: 360, height: 148 }}
+                      />
                     </div>
-                    <div className='flex flex-row gap-[2px]'>
-                      <CalendarDotIcon width={16} height={16} />
-                      <p className='text-sm text-gray-600'>
-                        {meeting.gatheringWeek / 7}주 동안
-                      </p>
-                    </div>
-                    <div className='flex flex-row gap-[2px]'>
-                      <BookIcon width={24} height={18} />
-                      <p className='text-sm text-gray-600'>
-                        매일 {meeting.readingTimeGoal}분
-                      </p>
+                    <div>
+                      <h3 className='text-lg font-semibold mb-3'>
+                        {meeting.name}
+                      </h3>
+                      <div className='flex flex-row gap-[2px]'>
+                        <UsersIcon width={16} height={16} />
+                        <p className='text-sm text-gray-600'>
+                          {meeting.currentCapacity}명 / {meeting.maxCapacity}명
+                        </p>
+                      </div>
+                      <div className='flex flex-row gap-[2px]'>
+                        <CalendarDotIcon width={16} height={16} />
+                        <p className='text-sm text-gray-600'>
+                          {meeting.gatheringWeek / 7}주 동안
+                        </p>
+                      </div>
+                      <div className='flex flex-row gap-[2px]'>
+                        <BookIcon width={24} height={18} />
+                        <p className='text-sm text-gray-600'>
+                          매일 {meeting.readingTimeGoal}분
+                        </p>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
+              </Link>
             ))}
           </div>
         </div>

--- a/app/_components/MainPageBody.tsx
+++ b/app/_components/MainPageBody.tsx
@@ -221,7 +221,7 @@ export default function MainPageBody() {
           </div>
           <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
             {filteredMeetings.map((meeting) => (
-              <Link href={`/meeting-detail/${meeting.id}}`} key={meeting.id}>
+              <Link href={`/meeting-detail/${meeting.id}`} key={meeting.id}>
                 <div className='h-[298px] border rounded-lg shadow-md hover:shadow-lg bg-white flex flex-col'>
                   <div className='w-full h-[148px] flex justify-center items-center bg-[#D9D9D9]'>
                     <Image

--- a/app/meeting-detail/[meetingsId]/_components/BookInfo.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/BookInfo.tsx
@@ -1,43 +1,44 @@
-/**
- * bookTitle: string;
- * author: string;
- * publisher: string;
- * publishDate: string;
- * star: Number;
- */
+import Image from 'next/image';
 
 interface BookInfoProps {
-  bookTitle: string;
-  author: string;
-  publisher: string;
-  publishDate: string;
-  star: number;
+  bookImage?: string;
+  bookTitle?: string;
+  author?: string;
+  publisher?: string;
+  publishDate?: string;
+  star?: number;
 }
 
 const BookInfo = ({
-  bookTitle,
-  author,
-  publisher,
-  publishDate,
-  star,
+  bookImage,
+  bookTitle = '책 이름',
+  author = '저자',
+  publisher = '출판사',
+  publishDate = '출판일',
+  star = 10,
 }: BookInfoProps) => {
   return (
     <>
       <div className='mt-[9px] py-[16px] px-[10px] flex flex-row border-[1px] border-[rgba(0, 0, 0, 0.10)]'>
-        <div className='w-[87px] h-[132px] flex justify-center items-center bg-orange-300'>
-          이미지 영역
+        <div className='w-[87px] h-[132px] flex justify-center items-center relative'>
+          <Image
+            src={bookImage}
+            alt='book-image'
+            layout='fill'
+            objectFit='cover'
+          />
         </div>
         <div className='ml-[18px]'>
           <span className='text-xl font-bold'>{bookTitle}</span>
           <div className='grid grid-cols-[1fr_2fr] mt-[9px]'>
             <span>저자</span>
-            <span>{author}</span>
+            <span className='ml-4'>{author}</span>
             <span>출판</span>
-            <span>{publisher}</span>
+            <span className='ml-4'>{publisher}</span>
             <span>발행일</span>
-            <span>{publishDate}</span>
+            <span className='ml-4'>{publishDate}</span>
             <span>평점</span>
-            <span>☆☆☆☆☆ {`${star}`}</span>
+            <span className='ml-4'>☆☆☆☆☆ {`${star}`}</span>
           </div>
         </div>
       </div>

--- a/app/meeting-detail/[meetingsId]/_components/MeetingDetailLeft.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/MeetingDetailLeft.tsx
@@ -1,21 +1,33 @@
+import { useMeetingContext } from '../_lib/MeetingDetailContext';
 import HeartIcon from '@/public/HeartIcon';
 import ShareIcon from '@/public/ShareIcon';
 import UserIcon from '@/public/UserIcon';
+import Image from 'next/image';
 
 export default function MeetingDetailLeft() {
+  const { meetingData, loading, error } = useMeetingContext();
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error: 데이터를 불러오지 못했습니다.</div>;
+
   return (
     <div className='w-[336px] flex flex-col'>
-      <div className='h-[189px] flex justify-center items-center bg-gray-300'>
-        이미지 영역
+      <div className='h-[189px] flex justify-center items-center relative bg-gray-300'>
+        <Image
+          src={`${meetingData?.thumbnail}`}
+          alt='meeting-thumbnail'
+          layout='fill'
+          objectFit='cover'
+        />
       </div>
       <div className='h-[60px] text-[20px] mt-[17px] font-bold'>
-        [매일 30분 읽기] 한강 디에센셜 함께 읽어요!
+        {meetingData?.name}
       </div>
       <div className='h-[36px] flex flex-row items-center mt-[15px]'>
         <div className='w-[2rem] h-[2rem] border-[0.925px] border-[#D1D5DB] bg-white rounded-full flex justify-center items-center'>
           <UserIcon width={36} height={36} />
         </div>
-        <div className='font-bold ml-[14px]'>닉네임</div>
+        <div className='font-bold ml-[14px]'>{meetingData?.owner}</div>
       </div>
       <div className='h-[65px] mt-[21px]'>
         <button className='w-full h-full bg-gray-300 font-bold'>

--- a/app/meeting-detail/[meetingsId]/_components/MeetingDetailRight.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/MeetingDetailRight.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useMeetingContext } from '../_lib/MeetingDetailContext';
 import { calculateEndDate } from '../_utils/calculateEndDate';
+import { calculateRemainingDays } from '../_utils/calculateRemainDays';
 import BookInfo from './BookInfo';
 import BookIcon from '@/public/BookIcon';
 import CalendarDotIcon from '@/public/CalendarDotIcon';
@@ -12,15 +13,18 @@ export default function MeetingDetailRight() {
   const { meetingData, loading, error } = useMeetingContext();
   const [endDate, setEndDate] = useState<string>('');
   const [meetingDuration, setMeetingDuration] = useState(0);
+  const [remainDays, setRemainDays] = useState(0);
 
   useEffect(() => {
     if (meetingData?.startDate && meetingData?.gatheringWeek) {
-      const res = calculateEndDate(
+      const calEndDate = calculateEndDate(
         meetingData.startDate,
         meetingData.gatheringWeek,
       );
-      setEndDate(res);
+      setEndDate(calEndDate);
+      const calRemainDays = calculateRemainingDays(calEndDate);
       setMeetingDuration(meetingData.gatheringWeek / 7);
+      setRemainDays(calRemainDays);
     }
   }, [meetingData]);
 
@@ -33,7 +37,7 @@ export default function MeetingDetailRight() {
         모집중
       </div>
       <div className='h-[49px] mt-[13px] font-bold text-3xl'>
-        N일뒤 모임이 시작됩니다.
+        {remainDays}일 뒤 모임이 시작됩니다.
       </div>
       <div className='grid grid-cols-[1fr_2fr] w-[40%] gap-3'>
         <UsersIcon width={25} height={25} />

--- a/app/meeting-detail/[meetingsId]/_components/MeetingDetailRight.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/MeetingDetailRight.tsx
@@ -1,53 +1,68 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useMeetingContext } from '../_lib/MeetingDetailContext';
+import { calculateEndDate } from '../_utils/calculateEndDate';
 import BookInfo from './BookInfo';
 import BookIcon from '@/public/BookIcon';
 import CalendarDotIcon from '@/public/CalendarDotIcon';
 import UsersIcon from '@/public/UsersIcon';
 
-const bookTitle = '디 에센셜: 한강(무선 보급판)';
-const author = '한강';
-const publisher = '문학동네';
-const publishDate = '2024.06.01';
-const star = 4.2;
-
 export default function MeetingDetailRight() {
+  const { meetingData, loading, error } = useMeetingContext();
+  const [endDate, setEndDate] = useState<string>('');
+  const [meetingDuration, setMeetingDuration] = useState(0);
+
+  useEffect(() => {
+    if (meetingData?.startDate && meetingData?.gatheringWeek) {
+      const res = calculateEndDate(
+        meetingData.startDate,
+        meetingData.gatheringWeek,
+      );
+      setEndDate(res);
+      setMeetingDuration(meetingData.gatheringWeek / 7);
+    }
+  }, [meetingData]);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error: 데이터를 불러오지 못했습니다.</div>;
+
   return (
     <div className='w-[654px] h-[670px] rounded-[4px] border-[1px] border-[rgba(0,0,0,0.3)] flex flex-col py-[23px] px-[24px]'>
-      {/* 모임 상태 */}
       <div className='w-[84px] h-[36px] py-[6px] px-[10px] box-border text-center rounded-[8px] bg-[#A0A0A0]'>
         모집중
       </div>
-      {/* 모임 안내 문구 */}
       <div className='h-[49px] mt-[13px] font-bold text-3xl'>
         N일뒤 모임이 시작됩니다.
       </div>
-      {/* 모임 규칙 */}
-      <div className='grid grid-cols-[1fr_2fr] w-[30%] gap-3'>
+      <div className='grid grid-cols-[1fr_2fr] w-[40%] gap-3'>
         <UsersIcon width={25} height={25} />
-        <div>참여 인원</div>
+        <div>
+          {meetingData?.currentCapacity}명 / {meetingData?.maxCapacity}명
+        </div>
         <BookIcon width={25} height={25} />
-        <div>독서 시간</div>
+        <div>매일 {meetingData?.readingTimeGoal}분</div>
         <CalendarDotIcon width={25} height={25} />
-        <div>독서 기간</div>
+        <div>{meetingDuration}주 동안</div>
       </div>
-      {/* 모임 시작, 종료일 */}
       <div className='h-[98px] flex flex-row justify-around items-center mt-[12px] bg-gray-200'>
         <div className='flex flex-col justify-center items-center text-xl'>
           <span>시작일</span>
-          <span className='font-bold'>12월 31일 월요일</span>
+          <span className='font-bold'>{meetingData?.startDate}</span>
         </div>
         <div className='flex flex-col justify-center items-center text-xl'>
           <span>종료일</span>
-          <span className='font-bold'>1월 15일 월요일</span>
+          <span className='font-bold'>{endDate}</span>
         </div>
       </div>
-      {/* 모임에서 읽을 책 정보 */}
       <h3 className='font-bold text-xl mt-6'>함께 읽을 책</h3>
       <BookInfo
-        bookTitle={bookTitle}
-        author={author}
-        publisher={publisher}
-        publishDate={publishDate}
-        star={star}
+        bookImage={meetingData?.bookImage}
+        bookTitle={meetingData?.bookTitle}
+        author={meetingData?.author}
+        publisher={meetingData?.publisher}
+        publishDate={meetingData?.publishDate}
+        star={meetingData?.star}
       />
       <button className='h-[49px] mt-[7px] bg-[#D9D9D9] font-medium text-[18px]'>
         리뷰 보러가기

--- a/app/meeting-detail/[meetingsId]/_lib/MeetingDetailContext.tsx
+++ b/app/meeting-detail/[meetingsId]/_lib/MeetingDetailContext.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React, {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import { fetchMeetingDetails } from './meetingDetail';
+import { IMeeting } from '@/app/types';
+import { useParams } from 'next/navigation';
+
+interface MeetingContextType {
+  meetingData: IMeeting | undefined;
+  loading: boolean;
+  error: boolean;
+}
+
+const MeetingContext = createContext<MeetingContextType | undefined>(undefined);
+
+const MeetingProvider = ({ children }: { children: ReactNode }) => {
+  const [meetingData, setMeetingData] = useState<IMeeting>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const params = useParams();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!params.meetingsId) {
+        setError(true);
+        setLoading(false);
+        return;
+      }
+      try {
+        const data = await fetchMeetingDetails(Number(params.meetingsId));
+        setMeetingData(data.result);
+        setLoading(false);
+      } catch (err) {
+        console.error('데이터를 가져오는 중 오류 발생:', err);
+        setError(true);
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [params.meetingsId]);
+
+  return (
+    <MeetingContext.Provider value={{ meetingData, loading, error }}>
+      {children}
+    </MeetingContext.Provider>
+  );
+};
+
+const useMeetingContext = () => {
+  const context = useContext(MeetingContext);
+  if (!context) {
+    throw new Error(
+      'ERROR: useMeetingContext는 MeetingProvider 내부에서만 사용가능합니다.',
+    );
+  }
+  return context;
+};
+
+export { MeetingProvider, useMeetingContext };

--- a/app/meeting-detail/[meetingsId]/_lib/meetingDetail.ts
+++ b/app/meeting-detail/[meetingsId]/_lib/meetingDetail.ts
@@ -1,0 +1,16 @@
+'use server';
+
+import { fetchAPIServer } from '@/lib/fetchAPI.server';
+
+export async function fetchMeetingDetails(gatheringId: number) {
+  const endpoint = `/api/gatheringSearch/${gatheringId}`;
+  const method = 'GET';
+
+  const data = await fetchAPIServer(endpoint, method);
+
+  if (data?.error) {
+    throw new Error(data.error.message || 'Failed to fetch meeting detail');
+  }
+
+  return data;
+}

--- a/app/meeting-detail/[meetingsId]/_utils/calculateEndDate.ts
+++ b/app/meeting-detail/[meetingsId]/_utils/calculateEndDate.ts
@@ -1,0 +1,7 @@
+import { addWeeks, format } from 'date-fns';
+
+export function calculateEndDate(startDate: string, weeks: number) {
+  const start = new Date(startDate);
+  const endDate = addWeeks(start, weeks);
+  return format(endDate, 'yyyy-MM-dd');
+}

--- a/app/meeting-detail/[meetingsId]/_utils/calculateRemainDays.ts
+++ b/app/meeting-detail/[meetingsId]/_utils/calculateRemainDays.ts
@@ -1,0 +1,8 @@
+import { differenceInCalendarDays } from 'date-fns';
+
+export function calculateRemainingDays(endDate: string) {
+  const today = new Date();
+  const end = new Date(endDate);
+  const remainingDays = differenceInCalendarDays(end, today);
+  return remainingDays;
+}

--- a/app/meeting-detail/[meetingsId]/page.tsx
+++ b/app/meeting-detail/[meetingsId]/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import MeetingDetailLeft from './_components/MeetingDetailLeft';
 import MeetingDetailRight from './_components/MeetingDetailRight';
 import MeetingDetailTabs from './_components/MeetingDetailTabs';

--- a/app/meeting-detail/[meetingsId]/page.tsx
+++ b/app/meeting-detail/[meetingsId]/page.tsx
@@ -1,55 +1,18 @@
-'use client';
-
-import { useEffect, useState } from 'react';
 import MeetingDetailLeft from './_components/MeetingDetailLeft';
 import MeetingDetailRight from './_components/MeetingDetailRight';
 import MeetingDetailTabs from './_components/MeetingDetailTabs';
-import { fetchMeetingDetails } from './_lib/meetingDetail';
-import { IMeeting } from '@/app/types';
-import { useParams } from 'next/navigation';
+import { MeetingProvider } from './_lib/MeetingDetailContext';
 
 export default function MeetingDetailPage() {
-  const [meetingData, setMeetingData] = useState<IMeeting[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
-  const params = useParams();
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const data = await fetchMeetingDetails(Number(params.meetingsId));
-        setMeetingData(data);
-        console.log(data);
-        setLoading(false);
-      } catch (err) {
-        console.error('데이터를 가져오는 중 오류 발생:', err);
-        setError(true);
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, []);
-
-  if (loading) {
-    return <div>Loading...</div>;
-  }
-
-  if (error) {
-    return <div>Error: 데이터를 불러오지 못했습니다.</div>;
-  }
-
-  if (!meetingData) {
-    return <div>데이터가 없습니다.</div>;
-  }
-
   return (
-    <div className='flex flex-col items-center justify-start mt-[131px] w-[1060px] h-[2000px] mb-20 mx-auto '>
-      <div className='w-full h-[670px] flex flex-row justify-between'>
-        <MeetingDetailLeft />
-        <MeetingDetailRight />
+    <MeetingProvider>
+      <div className='flex flex-col items-center justify-start mt-[131px] w-[1060px] h-[2000px] mb-20 mx-auto '>
+        <div className='w-full h-[670px] flex flex-row justify-between'>
+          <MeetingDetailLeft />
+          <MeetingDetailRight />
+        </div>
+        <MeetingDetailTabs />
       </div>
-      <MeetingDetailTabs />
-    </div>
+    </MeetingProvider>
   );
 }

--- a/app/meeting-detail/[meetingsId]/page.tsx
+++ b/app/meeting-detail/[meetingsId]/page.tsx
@@ -1,18 +1,54 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import MeetingDetailLeft from './_components/MeetingDetailLeft';
 import MeetingDetailRight from './_components/MeetingDetailRight';
 import MeetingDetailTabs from './_components/MeetingDetailTabs';
+import { fetchMeetingDetails } from './_lib/meetingDetail';
+import { IMeeting } from '@/app/types';
+import { useParams } from 'next/navigation';
 
 export default function MeetingDetailPage() {
+  const [meetingData, setMeetingData] = useState<IMeeting[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const params = useParams();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await fetchMeetingDetails(Number(params.meetingsId));
+        setMeetingData(data);
+        console.log(data);
+        setLoading(false);
+      } catch (err) {
+        console.error('데이터를 가져오는 중 오류 발생:', err);
+        setError(true);
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: 데이터를 불러오지 못했습니다.</div>;
+  }
+
+  if (!meetingData) {
+    return <div>데이터가 없습니다.</div>;
+  }
+
   return (
     <div className='flex flex-col items-center justify-start mt-[131px] w-[1060px] h-[2000px] mb-20 mx-auto '>
-      {/* 모임 상세페이지 메인 */}
       <div className='w-full h-[670px] flex flex-row justify-between'>
-        {/* 메인 좌측 파트*/}
         <MeetingDetailLeft />
-        {/* 메인 우측 파트*/}
         <MeetingDetailRight />
       </div>
-      {/* 모임 상세페이지 탭스 */}
       <MeetingDetailTabs />
     </div>
   );

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -18,6 +18,7 @@ export interface IMeeting {
   publisher: string;
   publishDate: string;
   star: number;
+  author: string;
   thumbnail: string;
   gatheringWeek: number;
 }


### PR DESCRIPTION
##  🧲 Pull Request

## #️⃣ 연관된 이슈
#66

## 📝 작업 내용
### 모임 상세페이지 헤더파트 api연결 및 기능구현
- 모임 상세페이지에 더미데이터를 활용하여 데이터를 출력했던 헤더부분을 
  api연결을 통해 실제데이터가 출력될 수 있도록 업데이트 진행
- 데이터를 가공하여 활용해야하는 경우가 존재하여 필요한 유틸함수 구현 
  - **calculateEndDate.ts**
    : 시작일('yyyy-mm-dd')과 모임기간( number타입 7의단위로 받음 )을 입력받아 
    모임 종료일을 리턴하는 함수
  - **calculateRemainDays**
    : 오늘날짜와 모집마감일('yyyy-mm-dd')를 입력받아 남은 일수를 리턴하는 함수

## 🔢 리뷰 요구사항 (선택)

## 🖼️ 스크린샷 (선택)
