### PR TITLE
Feat/review-filter 독서 리뷰 필터링 검색 무한 스크롤 적용

### DIFF
--- a/app/reviews/_components/BestReviews.tsx
+++ b/app/reviews/_components/BestReviews.tsx
@@ -26,7 +26,7 @@ export default function BestReviews() {
   const total = bookReviews?.length || 0;
 
   return (
-    <div>
+    <div className='w-full'>
       <h3 className='font-bold mb-4'>모읽러가 선정한 Best 리뷰</h3>
       <div>
         {Array.isArray(bookReviews) && bookReviews?.length > 0 && (

--- a/app/reviews/_components/Filter.tsx
+++ b/app/reviews/_components/Filter.tsx
@@ -5,9 +5,13 @@ import DropDownThinIcon from '../_svg/DropDownThinIcon';
 import DropUpThinIcon from '../_svg/DropUpThinIcon';
 import { BookReviewFilter } from '@/types/review';
 
-export default function Filter() {
+type Props = {
+  filter: BookReviewFilter;
+  onFilterChange: (filter: BookReviewFilter) => void;
+};
+
+export default function Filter({ filter, onFilterChange }: Props) {
   const [isOpen, setIsOpen] = useState(false);
-  const [filter, setFilter] = useState<BookReviewFilter>('ALL');
   const filters = [
     { label: '전체 보기', value: 'ALL' },
     { label: '🤗 따뜻한 위로', value: 'CS' },
@@ -19,9 +23,6 @@ export default function Filter() {
   ];
   const toggleOpen = () => {
     setIsOpen(!isOpen);
-  };
-  const changeFilter = (value: BookReviewFilter) => {
-    setFilter(value);
   };
   const applyButtonStyle = (value: BookReviewFilter) => {
     if (filter === value) {
@@ -35,14 +36,14 @@ export default function Filter() {
           <button
             key={value}
             className={`p-2.5 border rounded-full ${applyButtonStyle(value as BookReviewFilter)}`}
-            onClick={() => changeFilter(value as BookReviewFilter)}
+            onClick={() => onFilterChange(value as BookReviewFilter)}
           >
             {label}
           </button>
         ))}
         {!isOpen && (
           <div className='flex items-center w-18'>
-            <button className='flex items-center h-11 pl-2 border rounded-full'>
+            <div className='flex items-center h-11 pl-2 border rounded-full'>
               <span className='blur-[0.5px]'>📚</span>
               <button
                 className='w-11 h-11 rounded-full border'
@@ -50,7 +51,7 @@ export default function Filter() {
               >
                 <DropDownThinIcon className='w-7 h-7 mx-auto' />
               </button>
-            </button>
+            </div>
           </div>
         )}
         {isOpen && (
@@ -67,7 +68,7 @@ export default function Filter() {
           <button
             key={value}
             className={`p-2.5 border rounded-full  ${applyButtonStyle(value as BookReviewFilter)}`}
-            onClick={() => changeFilter(value as BookReviewFilter)}
+            onClick={() => onFilterChange(value as BookReviewFilter)}
           >
             {label}
           </button>

--- a/app/reviews/_components/Filter.tsx
+++ b/app/reviews/_components/Filter.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState } from 'react';
+import DropDownThinIcon from '../_svg/DropDownThinIcon';
+import DropUpThinIcon from '../_svg/DropUpThinIcon';
+import { BookReviewFilter } from '@/types/review';
+
+export default function Filter() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [filter, setFilter] = useState<BookReviewFilter>('ALL');
+  const filters = [
+    { label: '전체 보기', value: 'ALL' },
+    { label: '🤗 따뜻한 위로', value: 'CS' },
+    { label: '🤩 흥미진진', value: 'FUN' },
+    { label: '😢 눈물샘 자극', value: 'SAD' },
+    { label: '📚 지식 쏙쏙', value: 'KL' },
+    { label: '⏳ 시간 순삭', value: 'TIME' },
+    { label: '🔍 새로운 발견', value: 'FIND' },
+  ];
+  const toggleOpen = () => {
+    setIsOpen(!isOpen);
+  };
+  const changeFilter = (value: BookReviewFilter) => {
+    setFilter(value);
+  };
+  const applyButtonStyle = (value: BookReviewFilter) => {
+    if (filter === value) {
+      return 'bg-black text-white font-bold';
+    }
+  };
+  return (
+    <div className='flex flex-col gap-2'>
+      <div className='flex flex-wrap gap-2.5 relative'>
+        {filters.slice(0, 4).map(({ label, value }) => (
+          <button
+            key={value}
+            className={`p-2.5 border rounded-full ${applyButtonStyle(value as BookReviewFilter)}`}
+            onClick={() => changeFilter(value as BookReviewFilter)}
+          >
+            {label}
+          </button>
+        ))}
+        {!isOpen && (
+          <div className='flex items-center w-18'>
+            <button className='flex items-center h-11 pl-2 border rounded-full'>
+              <span className='blur-[0.5px]'>📚</span>
+              <button
+                className='w-11 h-11 rounded-full border'
+                onClick={toggleOpen}
+              >
+                <DropDownThinIcon className='w-7 h-7 mx-auto' />
+              </button>
+            </button>
+          </div>
+        )}
+        {isOpen && (
+          <button
+            className='w-11 h-11 rounded-full border'
+            onClick={toggleOpen}
+          >
+            <DropUpThinIcon className='w-7 h-7 mx-auto' />
+          </button>
+        )}
+      </div>
+      <div className={`flex gap-2.5 ${isOpen ? 'opacity-100' : 'opacity-0'}`}>
+        {filters.slice(4).map(({ label, value }) => (
+          <button
+            key={value}
+            className={`p-2.5 border rounded-full  ${applyButtonStyle(value as BookReviewFilter)}`}
+            onClick={() => changeFilter(value as BookReviewFilter)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/reviews/_components/PendingReviewBox.tsx
+++ b/app/reviews/_components/PendingReviewBox.tsx
@@ -9,6 +9,7 @@ export default function PendingReviewBox() {
   const { data: reviews } = useQuery({
     queryKey: ['reviews', 'best'],
     queryFn: getBestAndPendingReviews,
+    staleTime: 60 * 1000,
   });
   if (!reviews) return null;
   const { bookResponseList } = reviews;

--- a/app/reviews/_components/Review.tsx
+++ b/app/reviews/_components/Review.tsx
@@ -1,0 +1,29 @@
+import CommentIcon from '../_svg/CommentIcon';
+import LikeIcon from '../_svg/LikeIcon';
+import { BookReview } from '@/types/book';
+import Image from 'next/image';
+
+export default function Review({ review }: { review: BookReview }) {
+  return (
+    <div className='border w-[520px]'>
+      <h3 className='p-2'>{review.title}</h3>
+      <div className='flex gap-2.5 p-3 border-y'>
+        <Image src={review.bookImage} width={130} height={195} alt='책 표지' />
+        <p>{review.content}</p>
+      </div>
+      <div className='flex justify-between items-center px-5 py-3'>
+        <div className='flex items-center gap-2.5'>
+          <div className='w-10 h-10 bg-[#D9D9D9] rounded-full'></div>
+          <span>{review.userName}</span>
+          <p>{review.createTime}</p>
+        </div>
+        <div className='flex gap-1'>
+          <LikeIcon className='w-5 h-5' />
+          <span className='ml-1'>{review.likes}</span>
+          <CommentIcon className='w-5 h-5' />
+          <p className='ml-1'>0</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/reviews/_components/ReviewDashboard.tsx
+++ b/app/reviews/_components/ReviewDashboard.tsx
@@ -1,5 +1,6 @@
 import BestReviews from './BestReviews';
 import PendingReviewBox from './PendingReviewBox';
+import ReviewList from './ReviewList';
 import UserInfo from './UserInfo';
 
 export default function ReviewDashboard() {
@@ -9,7 +10,10 @@ export default function ReviewDashboard() {
         <UserInfo />
         <PendingReviewBox />
       </div>
-      <BestReviews />
+      <div className='flex flex-col items-center gap-11'>
+        <BestReviews />
+        <ReviewList />
+      </div>
     </div>
   );
 }

--- a/app/reviews/_components/ReviewList.tsx
+++ b/app/reviews/_components/ReviewList.tsx
@@ -1,9 +1,41 @@
+'use client';
+
+import { useState } from 'react';
 import Filter from './Filter';
+import Review from './Review';
+import InfiniteScroll from '@/components/InfiniteScroll';
+import { useReviewsInfinityQuery } from '@/hooks/useReviewsInfinityQuery';
+import { BookReviewFilter } from '@/types/review';
 
 export default function ReviewList() {
+  const [filter, setFilter] = useState<BookReviewFilter>('ALL');
+  const { isLoading, data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useReviewsInfinityQuery(filter);
+
+  const handleView = () => {
+    if (!isFetchingNextPage && hasNextPage) {
+      fetchNextPage();
+    }
+  };
+
+  if (isLoading) return <p>Loading...</p>;
+  const reviews = data?.pages.flatMap((page) => page.bookReviews) || [];
+
   return (
     <section>
-      <Filter />
+      <Filter
+        filter={filter}
+        onFilterChange={(newFilter) => setFilter(newFilter)}
+      />
+      <InfiniteScroll
+        className='flex flex-col gap-9'
+        isFetching={isFetchingNextPage}
+        list={reviews}
+        renderItem={(review) => <Review key={review.id} review={review} />}
+        onView={handleView}
+        hasMore={!!hasNextPage}
+        emptyMessage={`${filter}에 해당하는 리뷰가 없습니다.`}
+      />
     </section>
   );
 }

--- a/app/reviews/_components/ReviewList.tsx
+++ b/app/reviews/_components/ReviewList.tsx
@@ -1,0 +1,9 @@
+import Filter from './Filter';
+
+export default function ReviewList() {
+  return (
+    <section>
+      <Filter />
+    </section>
+  );
+}

--- a/app/reviews/_lib/getFilteredBookReviews.ts
+++ b/app/reviews/_lib/getFilteredBookReviews.ts
@@ -1,0 +1,22 @@
+import { fetchAPIClient } from '@/lib/fetchAPI.client';
+import { BookReview } from '@/types/book';
+import { BookReviewFilter } from '@/types/review';
+
+export type BookReviewResponse = {
+  bookReviews: BookReview[];
+  hasNext?: boolean;
+};
+const SIZE = 10;
+export const getFilteredBookReviews = async (
+  filter: BookReviewFilter,
+  pageParam: number,
+): Promise<BookReviewResponse> => {
+  const res = await fetchAPIClient(
+    `/api/review/search/tag?tag=${filter}&page=${pageParam}&size=${SIZE}`,
+    'GET',
+  );
+  if (res.code === 'SUCCESS') {
+    return res.result;
+  }
+  throw new Error(`Failed to fetch book reviews: ${res.message}`);
+};

--- a/app/reviews/_lib/getFilteredBookReviewsServer.ts
+++ b/app/reviews/_lib/getFilteredBookReviewsServer.ts
@@ -1,0 +1,23 @@
+import { fetchAPIServer } from '@/lib/fetchAPI.server';
+import { BookReview } from '@/types/book';
+import { BookReviewFilter } from '@/types/review';
+
+type BookReviewResponse = {
+  bookReviews: BookReview[];
+  hasNext?: boolean;
+};
+const SIZE = 2;
+
+export const getFilteredBookReviewsServer = async (
+  filter: BookReviewFilter,
+  pageParam: number,
+): Promise<BookReviewResponse> => {
+  const res = await fetchAPIServer(
+    `/api/review/search/tag?tag=${filter}&page=${pageParam}&size=${SIZE}`,
+    'GET',
+  );
+  if (res.code === 'SUCCESS') {
+    return res.result;
+  }
+  throw new Error(`Failed to fetch book reviews: ${res.message}`);
+};

--- a/app/reviews/_lib/getFilteredBookReviewsServer.ts
+++ b/app/reviews/_lib/getFilteredBookReviewsServer.ts
@@ -6,7 +6,7 @@ type BookReviewResponse = {
   bookReviews: BookReview[];
   hasNext?: boolean;
 };
-const SIZE = 2;
+const SIZE = 10;
 
 export const getFilteredBookReviewsServer = async (
   filter: BookReviewFilter,

--- a/app/reviews/_svg/DropDownThinIcon.tsx
+++ b/app/reviews/_svg/DropDownThinIcon.tsx
@@ -1,0 +1,18 @@
+export default function DropDownThinIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      {...props}
+      xmlns='http://www.w3.org/2000/svg'
+      viewBox='0 0 28 28'
+      fill='none'
+    >
+      <path
+        d='M7.4001 10.6988L14.0001 17.2988L20.6001 10.6988'
+        stroke='black'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  );
+}

--- a/app/reviews/_svg/DropUpThinIcon.tsx
+++ b/app/reviews/_svg/DropUpThinIcon.tsx
@@ -1,0 +1,18 @@
+export default function DropUpThinIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      {...props}
+      xmlns='http://www.w3.org/2000/svg'
+      viewBox='0 0 28 28'
+      fill='none'
+    >
+      <path
+        d='M20.5999 17.3012L13.9999 10.7012L7.3999 17.3012'
+        stroke='black'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  );
+}

--- a/app/reviews/page.tsx
+++ b/app/reviews/page.tsx
@@ -5,12 +5,19 @@ import {
 } from '@tanstack/react-query';
 import ReviewDashboard from './_components/ReviewDashboard';
 import { getBestAndPendingReviewsServer } from './_lib/getBestAndPendingReviewsServer';
+import { getFilteredBookReviewsServer } from './_lib/getFilteredBookReviewsServer';
 
 export default async function ReviewsPage() {
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery({
     queryKey: ['reviews', 'best'],
     queryFn: getBestAndPendingReviewsServer,
+  });
+  await queryClient.prefetchInfiniteQuery({
+    queryKey: ['reviews', 'ALL'],
+    queryFn: ({ pageParam = 0 }) =>
+      getFilteredBookReviewsServer('ALL', pageParam),
+    initialPageParam: 0,
   });
   const dehydrateState = dehydrate(queryClient);
   return (

--- a/components/InfiniteScroll.tsx
+++ b/components/InfiniteScroll.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react';
+
+type Props<T> = {
+  list: T[];
+  renderItem: (item: T) => JSX.Element;
+  onView: () => void;
+  className?: string;
+  hasMore: boolean;
+  isFetching: boolean;
+  emptyMessage: string;
+};
+
+export default function InfiniteScroll<T>({
+  list,
+  renderItem,
+  onView,
+  className,
+  hasMore,
+  isFetching,
+  emptyMessage,
+}: Props<T>) {
+  const targetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!targetRef.current) return;
+    const callback = (entries: IntersectionObserverEntry[]) => {
+      if (entries[0].isIntersecting) {
+        onView();
+      }
+    };
+    const observer = new IntersectionObserver(callback, {
+      threshold: 0,
+    });
+    observer.observe(targetRef.current);
+    return () => observer && observer.disconnect();
+  }, [onView]);
+
+  if (!list.length) {
+    return <p>{emptyMessage}</p>;
+  }
+
+  return (
+    <div className={className}>
+      {list.map((item) => renderItem(item))}
+      {hasMore && (
+        <div ref={targetRef} className='h-[50px]'>
+          {isFetching && <p>Loading...</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/hooks/useReviewsInfinityQuery.ts
+++ b/hooks/useReviewsInfinityQuery.ts
@@ -1,0 +1,22 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import {
+  BookReviewResponse,
+  getFilteredBookReviews,
+} from '@/app/reviews/_lib/getFilteredBookReviews';
+import { BookReviewFilter } from '@/types/review';
+
+export const useReviewsInfinityQuery = (filter: BookReviewFilter) => {
+  return useInfiniteQuery<BookReviewResponse, Error>({
+    queryKey: ['reviews', filter],
+    queryFn: ({ pageParam = 0 }) =>
+      getFilteredBookReviews(filter, pageParam as number),
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.hasNext) {
+        return allPages.length;
+      }
+      return undefined;
+    },
+    staleTime: 30 * 1000,
+    initialPageParam: 0,
+  });
+};

--- a/types/book.ts
+++ b/types/book.ts
@@ -22,3 +22,15 @@ export type PendingBookReview = {
   image: string;
   gatheringId: number;
 };
+export type BookReview = {
+  id: number;
+  userId: string;
+  title: string;
+  apprCd: string;
+  content: string;
+  likes: number;
+  createTime: string;
+  userName: string;
+  bookImage: string;
+  userLikeCk?: boolean;
+};

--- a/types/review.ts
+++ b/types/review.ts
@@ -1,0 +1,8 @@
+export type BookReviewFilter =
+  | 'ALL'
+  | 'CS'
+  | 'FUN'
+  | 'SAD'
+  | 'KL'
+  | 'TIME'
+  | 'FIND';


### PR DESCRIPTION
##  🧲 Pull Request

## #️⃣ 연관된 이슈

>  #72 

## 📝 작업 내용
### 무한 스크롤 구현 및 SSR 데이터 개수 수정
무한 스크롤 컴포넌트를 통해 리스트 데이터를 넘겨주고, 화면 끝에 도달할 때 추가 데이터를 요청하도록 구현했습니다.

#### 발생한 문제
SSR로 리뷰 데이터를 2개만 가져오도록 설정했으나, 클라이언트 컴포넌트에서 page = 0의 데이터를 추가로 요청하고, 기존 SSR 데이터를 합치는 과정에서 문제가 발생했습니다.

예를 들어, 캐싱이 끝난 후 기존 필터('ALL')를 다시 선택했을 때, 총 데이터가 11개라면 10개만 불러오는 현상이 있었습니다.

#### 해결 방법
SSR로 가져오는 데이터의 개수를 10개로 변경하여 해당 문제를 해결했습니다. 



## 🔢 리뷰 요구사항 (선택)
>

## 🖼️ 스크린샷 (선택)
<img src='https://github.com/user-attachments/assets/cfdc359c-39ec-4280-8308-0266f61a3ca5' width='400'/>
<p> 필터 전체보기인 경우 </p>
<img src='https://github.com/user-attachments/assets/f00343e1-7e68-4d90-8f7e-d6880b5d52d6' width='400' />
<p>필터가 변경된 경우</p>
