### PR TITLE
Style/detailpage-UI 모임 상세페이지 UI 업데이트

### DIFF
--- a/app/meeting-detail/[meetingsId]/_components/BookInfo.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/BookInfo.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import Image from 'next/image';
 
 interface BookInfoProps {
@@ -7,6 +8,7 @@ interface BookInfoProps {
   publisher?: string;
   publishDate?: string;
   star?: number;
+  children?: ReactNode;
 }
 
 const BookInfo = ({
@@ -16,31 +18,35 @@ const BookInfo = ({
   publisher = '출판사',
   publishDate = '출판일',
   star = 10,
+  children,
 }: BookInfoProps) => {
   return (
     <>
-      <div className='mt-[9px] py-[16px] px-[10px] flex flex-row border-[1px] border-[rgba(0, 0, 0, 0.10)]'>
-        <div className='w-[87px] h-[132px] flex justify-center items-center relative'>
-          <Image
-            src={bookImage}
-            alt='book-image'
-            layout='fill'
-            objectFit='cover'
-          />
-        </div>
-        <div className='ml-[18px]'>
-          <span className='text-xl font-bold'>{bookTitle}</span>
-          <div className='grid grid-cols-[1fr_2fr] mt-[9px]'>
-            <span>저자</span>
-            <span className='ml-4'>{author}</span>
-            <span>출판</span>
-            <span className='ml-4'>{publisher}</span>
-            <span>발행일</span>
-            <span className='ml-4'>{publishDate}</span>
-            <span>평점</span>
-            <span className='ml-4'>☆☆☆☆☆ {`${star}`}</span>
+      <div className='mt-[9px] py-[16px] px-[10px] flex flex-col border-[1px] border-[rgba(0, 0, 0, 0.10)]'>
+        <div className='flex flex-row'>
+          <div className='w-[87px] h-[132px] flex justify-center items-center relative'>
+            <Image
+              src={bookImage}
+              alt='book-image'
+              layout='fill'
+              objectFit='cover'
+            />
+          </div>
+          <div className='ml-[18px]'>
+            <span className='text-xl font-bold'>{bookTitle}</span>
+            <div className='grid grid-cols-[1fr_2fr] mt-[9px]'>
+              <span>저자</span>
+              <span className='ml-4'>{author}</span>
+              <span>출판</span>
+              <span className='ml-4'>{publisher}</span>
+              <span>발행일</span>
+              <span className='ml-4'>{publishDate}</span>
+              <span>평점</span>
+              <span className='ml-4'>☆☆☆☆☆ {`${star}`}</span>
+            </div>
           </div>
         </div>
+        {children ? <div className='mt-4'>{children}</div> : <></>}
       </div>
     </>
   );

--- a/app/meeting-detail/[meetingsId]/_components/MeetingDetailLeft.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/MeetingDetailLeft.tsx
@@ -1,12 +1,14 @@
 import { IMeetingDetail } from '@/app/types';
 import HeartIcon from '@/public/HeartIcon';
+import InfoIcon from '@/public/InfoIcon';
+import MeetingOwnerIcon from '@/public/MeetingOwnerIcon';
 import ShareIcon from '@/public/ShareIcon';
 import UserIcon from '@/public/UserIcon';
 import Image from 'next/image';
 
 export default function MeetingDetailLeft({ data }: IMeetingDetail) {
   return (
-    <div className='w-[336px] flex flex-col'>
+    <div className='w-[336px] sticky top-0 flex flex-col'>
       <div className='h-[189px] flex justify-center items-center relative bg-gray-300'>
         <Image
           src={`${data?.thumbnail}`}
@@ -15,21 +17,24 @@ export default function MeetingDetailLeft({ data }: IMeetingDetail) {
           objectFit='cover'
         />
       </div>
-      <div className='h-[60px] text-[20px] mt-[17px] font-bold'>
-        {data?.name}
-      </div>
-      <div className='h-[36px] flex flex-row items-center mt-[15px]'>
-        <div className='w-[2rem] h-[2rem] border-[0.925px] border-[#D1D5DB] bg-white rounded-full flex justify-center items-center'>
+      <div className='text-[20px] mt-[16px] font-bold'>{data?.name}</div>
+      <div className='h-[36px] flex flex-row items-center mt-[16px]'>
+        <div className='w-[32px] h-[32px] border-[0.925px] border-[#D1D5DB] bg-white rounded-full flex justify-center items-center'>
           <UserIcon width={36} height={36} />
         </div>
         <div className='font-bold ml-[14px]'>{data?.owner}</div>
+        <MeetingOwnerIcon width={16} height={16} className='ml-1' />
       </div>
       <div className='h-[65px] mt-[21px]'>
-        <button className='w-full h-full bg-gray-300 font-bold'>
-          모임 함께하기
+        <button className='w-full h-full text-lg bg-gray-300 font-bold'>
+          모임 참여하기
         </button>
       </div>
-      <div className='h-[24px] flex flex-row justify-center items-center gap-6 mt-[36px]'>
+      <div className='flex flex-row justify-center items-center text-xs mt-4'>
+        <InfoIcon width={14} height={14} />
+        채팅방은 모임 시작일부터 입장 가능합니다.
+      </div>
+      <div className='h-[24px] flex flex-row justify-center items-center gap-6 mt-5'>
         <div className='flex flex-row gap-2'>
           <ShareIcon width={24} height={24} />
           <span>공유하기</span>

--- a/app/meeting-detail/[meetingsId]/_components/MeetingDetailLeft.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/MeetingDetailLeft.tsx
@@ -32,7 +32,7 @@ export default function MeetingDetailLeft({ data }: IMeetingDetail) {
       </div>
       <div className='flex flex-row justify-center items-center text-xs mt-4'>
         <InfoIcon width={14} height={14} />
-        채팅방은 모임 시작일부터 입장 가능합니다.
+        <span className='ml-2'>채팅방은 모임 시작일부터 입장 가능합니다.</span>
       </div>
       <div className='h-[24px] flex flex-row justify-center items-center gap-6 mt-5'>
         <div className='flex flex-row gap-2'>

--- a/app/meeting-detail/[meetingsId]/_components/MeetingDetailLeft.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/MeetingDetailLeft.tsx
@@ -25,6 +25,7 @@ export default function MeetingDetailLeft({ data }: IMeetingDetail) {
         <div className='font-bold ml-[14px]'>{data?.owner}</div>
         <MeetingOwnerIcon width={16} height={16} className='ml-1' />
       </div>
+      {/* TODO (희원) 모임 참여하기 버튼 연결하기 */}
       <div className='h-[65px] mt-[21px]'>
         <button className='w-full h-full text-lg bg-gray-300 font-bold'>
           모임 참여하기
@@ -34,6 +35,7 @@ export default function MeetingDetailLeft({ data }: IMeetingDetail) {
         <InfoIcon width={14} height={14} />
         <span className='ml-2'>채팅방은 모임 시작일부터 입장 가능합니다.</span>
       </div>
+      {/* TODO (희원) 모임 공유하기, 찜하기 버튼 연결하기 */}
       <div className='h-[24px] flex flex-row justify-center items-center gap-6 mt-5'>
         <div className='flex flex-row gap-2'>
           <ShareIcon width={24} height={24} />

--- a/app/meeting-detail/[meetingsId]/_components/MeetingDetailRight.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/MeetingDetailRight.tsx
@@ -34,6 +34,7 @@ export default function MeetingDetailRight({ data }: IMeetingDetail) {
         <CalendarDotIcon width={25} height={25} />
         <div>{meetingDuration}주 동안</div>
       </div>
+      {/* TODO (희원) 시작일, 종료일 날짜 데이터 출력하는 형식 변경  YYYY-MM-DD -> MM월 DD일 X요일 */}
       <div className='h-[98px] flex flex-row justify-around items-center mt-10 bg-[#F8F8F8]'>
         <div className='w-full h-[90%] flex flex-col justify-center items-center text-xl border-r-[1px] border-[rgba(0, 0, 0, 0.10)]'>
           <span>시작일</span>
@@ -53,6 +54,7 @@ export default function MeetingDetailRight({ data }: IMeetingDetail) {
         publishDate={data?.publishDate}
         star={data?.star}
       >
+        {/* TODO (희원) 독서 리뷰보러가기 : 독서 리뷰 페이지 연결하기 */}
         <button className='w-full h-[49px] mt-[7px] bg-[#CCCCCC] font-medium text-lg'>
           독서 리뷰 보러가기
         </button>

--- a/app/meeting-detail/[meetingsId]/_components/MeetingDetailRight.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/MeetingDetailRight.tsx
@@ -17,34 +17,34 @@ export default function MeetingDetailRight({ data }: IMeetingDetail) {
   const meetingDuration = data.gatheringWeek / 7;
 
   return (
-    <div className='w-[654px] h-[670px] rounded-[4px] border-[1px] border-[rgba(0,0,0,0.3)] flex flex-col py-[23px] px-[24px]'>
+    <div className='w-[654px] min-h-[600px] rounded-[4px] border-[1px] py-[23px] px-[24px] border-[rgba(0,0,0,0.3)] flex flex-col '>
       <div className='w-[84px] h-[36px] py-[6px] px-[10px] box-border text-center rounded-[8px] bg-[#A0A0A0]'>
         모집중
       </div>
       <div className='h-[49px] mt-[13px] font-bold text-3xl'>
         {remainDays}일 뒤 모임이 시작됩니다.
       </div>
-      <div className='grid grid-cols-[1fr_2fr] w-[40%] gap-3'>
+      <div className='grid grid-cols-[1fr_5fr] w-[40%] gap-3'>
         <UsersIcon width={25} height={25} />
         <div>
-          {data?.currentCapacity}명 / {data?.maxCapacity}명
+          참여 {data?.currentCapacity}명 / 정원 {data?.maxCapacity}명
         </div>
         <BookIcon width={25} height={25} />
         <div>매일 {data?.readingTimeGoal}분</div>
         <CalendarDotIcon width={25} height={25} />
         <div>{meetingDuration}주 동안</div>
       </div>
-      <div className='h-[98px] flex flex-row justify-around items-center mt-[12px] bg-gray-200'>
-        <div className='flex flex-col justify-center items-center text-xl'>
+      <div className='h-[98px] flex flex-row justify-around items-center mt-10 bg-[#F8F8F8]'>
+        <div className='w-full h-[90%] flex flex-col justify-center items-center text-xl border-r-[1px] border-[rgba(0, 0, 0, 0.10)]'>
           <span>시작일</span>
           <span className='font-bold'>{data?.startDate}</span>
         </div>
-        <div className='flex flex-col justify-center items-center text-xl'>
+        <div className='w-full h-[90%] flex flex-col justify-center items-center text-xl'>
           <span>종료일</span>
           <span className='font-bold'>{endDate}</span>
         </div>
       </div>
-      <h3 className='font-bold text-xl mt-6'>함께 읽을 책</h3>
+      <h3 className='font-bold text-xl mt-10'>함께 읽을 책</h3>
       <BookInfo
         bookImage={data?.bookImage}
         bookTitle={data?.bookTitle}
@@ -52,10 +52,11 @@ export default function MeetingDetailRight({ data }: IMeetingDetail) {
         publisher={data?.publisher}
         publishDate={data?.publishDate}
         star={data?.star}
-      />
-      <button className='h-[49px] mt-[7px] bg-[#D9D9D9] font-medium text-[18px]'>
-        리뷰 보러가기
-      </button>
+      >
+        <button className='w-full h-[49px] mt-[7px] bg-[#CCCCCC] font-medium text-lg'>
+          독서 리뷰 보러가기
+        </button>
+      </BookInfo>
     </div>
   );
 }

--- a/app/meeting-detail/[meetingsId]/_components/MeetingDetailTabs.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/MeetingDetailTabs.tsx
@@ -13,7 +13,7 @@ export default function MeetingDetailTabs({ gatheringId }: MeetingInfo) {
 
   const tabs = [
     { id: 'meeting-info', title: '모임 소개' },
-    { id: 'meeting-reviews', title: '모임 리뷰' },
+    { id: 'meeting-reviews', title: '모임 후기' },
   ];
 
   return (

--- a/app/meeting-detail/[meetingsId]/_components/MeetingInfo.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/MeetingInfo.tsx
@@ -7,8 +7,11 @@ import BookInfo from './BookInfo';
 import { IMeetingInfo } from '@/app/types';
 import AvatarIcon from '@/public/AvatarIcon';
 import ChevronDownIcon from '@/public/ChevronDownIcon';
+import ChevronUpIcon from '@/public/ChevronUpIcon';
 import ClosedBookIcon from '@/public/ClosedBookIcon';
+import InfoIcon from '@/public/InfoIcon';
 
+// TODO (희원) 예상 독서량에 필요한 데이터가 API에 없는상태 : API수정되는대로 로직수정하고 아래주석제거
 // const expectedReadingAmount = targetTime * goalDays;
 
 interface MeetingInfoProps {
@@ -29,9 +32,9 @@ export default function MeetingInfo({ gatheringId }: MeetingInfoProps) {
       setMeetingInfo(data.result);
     }
   }, [data]);
+  console.log(meetingInfo);
 
   const [bookMoreInfoToggle, setBooMoreInfoToggle] = useState(false);
-  // const meetingDuration = 모임기간(일) / 7
 
   const bookMoreInfoButtonHandler = () => {
     setBooMoreInfoToggle(!bookMoreInfoToggle);
@@ -49,8 +52,11 @@ export default function MeetingInfo({ gatheringId }: MeetingInfoProps) {
   return (
     <>
       <div className='w-full'>
+        {/* TODO (희원) 모임기간에 대한 API데이터가 없음 : 백엔드에 요청완료, 수정되는대로 코드수정 */}
         <div>
-          <h2 className='text-2xl font-bold'>주 동안</h2>
+          <h2 className='text-2xl font-bold'>
+            {meetingInfo?.gatheringWeek}주 동안
+          </h2>
           <h2 className='text-2xl'>
             <span className='font-bold'></span>
             함께 읽어요
@@ -67,7 +73,10 @@ export default function MeetingInfo({ gatheringId }: MeetingInfoProps) {
           </div>
         </div>
         <div className='mt-[23px] border-b-[1px] border-[rgba(0, 0, 0, 0.10)]'>
-          <h6 className='text-18px font-bold'>책소개</h6>
+          <div className='flex flex-row gap-2'>
+            <h6 className='text-18px font-bold'>책소개</h6>
+            <InfoIcon width={24} height={24} />
+          </div>
           <div
             className={`relative mt-[10px] ${bookMoreInfoToggle ? '' : 'h-[70px] overflow-y-hidden'}`}
           >
@@ -79,17 +88,18 @@ export default function MeetingInfo({ gatheringId }: MeetingInfoProps) {
           {bookMoreInfoToggle ? (
             <div
               onClick={() => bookMoreInfoButtonHandler()}
-              className='cursor-pointer flex flex-row justify-end'
+              className='cursor-pointer flex flex-row justify-end mb-3'
             >
-              <span>접기</span>
-              <ChevronDownIcon width={24} height={24} />
+              <span className='mr-1'>접어두기</span>
+              <ChevronUpIcon width={24} height={24} />
             </div>
           ) : (
             <div
               onClick={() => bookMoreInfoButtonHandler()}
-              className='cursor-pointer flex flex-row justify-end'
+              className='cursor-pointer flex flex-row justify-end mb-3'
             >
-              <span>더보기</span>
+              <span className='mr-1'>더보기</span>
+              <ChevronDownIcon width={24} height={24} />
             </div>
           )}
         </div>
@@ -104,7 +114,7 @@ export default function MeetingInfo({ gatheringId }: MeetingInfoProps) {
         </div>
         <div className='pb-[28px] border-b-[1px] border-[rgba(0, 0, 0, 0.10)]'>
           <div className='mt-[40px] '>
-            <h6 className='text-[18px] font-bold'>독서 가이드</h6>
+            <h6 className='text-lg font-bold'>독서 가이드</h6>
             <div className='mt-[10px] py-[16px] px-[12px] gap-[7px] flex flex-col bg-[#F8F8F8] text-[18px]'>
               <div className='flex flex-row items-center justify-start gap-[6px] text-[14px] text-gray-400'>
                 <div className='flex flex-row py-[2px] px-[6px] rounded-[2px] bg-[#E0E0E0] gap-[4px] w-[45px] items-center justify-center'>
@@ -113,6 +123,8 @@ export default function MeetingInfo({ gatheringId }: MeetingInfoProps) {
                 </div>
                 <span>{meetingInfo?.bookTitle}</span>
               </div>
+              {/* TODO (희원) 전체 책페이지에 대한 API 데이터 없음 : 백엔드에
+              요청완료, 수정되는대로 아래 로직 완성 + 주석제거 */}
               {/* {expectedReadingAmount >= totalPages ? (
                 <span className='font-bold text-[18px]'>
                   모임 기간 안에 완독할 가능성이 높은 책이에요!
@@ -121,7 +133,10 @@ export default function MeetingInfo({ gatheringId }: MeetingInfoProps) {
                 <></>
               )} */}
               <span>전체 페이지 수 </span>
-              <span>기간 내 예상 독서량 364페이지 이상</span>
+              <div className='flex flex-row'>
+                <span className='mr-2'>기간 내 예상 독서량 364페이지 이상</span>
+                <InfoIcon width={24} height={24} color='#A9A9A9' />
+              </div>
             </div>
             <div className='mt-[20px] flex flex-col text-[18px]'>
               <span>

--- a/app/meeting-detail/[meetingsId]/_components/MeetingReviews.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/MeetingReviews.tsx
@@ -4,8 +4,7 @@ import StarBlankIcon from '@/public/StarBlankIcon';
 import StarFillIcon from '@/public/StarFillIcon';
 
 export default function MeetingReviews() {
-  /* (희원) 임시 값 사용 -> 데이터 api 받아올 예정 */
-  /* (희원) 일단 4.2면 4개 채워지는 방식으로 구현 */
+  /* TODO (희원) API 오류로 호출불가 : 수정요청완료, 수정되면 더미데이터 삭제 + API데이터를 활용하도록 변경 */
   const starScore = 4.2;
   const stisfactionLevel = ['만족해요', '보통이에요', '아쉬웠어요'];
   const stisfactionValue = [98, 1, 1];
@@ -17,7 +16,7 @@ export default function MeetingReviews() {
       reviewId: 1,
       createDate: '2024-12-09',
       reviewContent:
-        '리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다.',
+        '리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. ',
     },
     {
       userName: 'kimgathering',
@@ -25,7 +24,7 @@ export default function MeetingReviews() {
       reviewId: 2,
       createDate: '2024-12-10',
       reviewContent:
-        '리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. ',
+        '리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다.  ',
     },
     {
       userName: 'kimgathering',
@@ -33,7 +32,7 @@ export default function MeetingReviews() {
       reviewId: 3,
       createDate: '2024-12-11',
       reviewContent:
-        '리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. ',
+        '리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다.  ',
     },
     {
       userName: 'kimgathering',
@@ -41,14 +40,14 @@ export default function MeetingReviews() {
       reviewId: 4,
       createDate: '2024-12-18',
       reviewContent:
-        '리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. ',
+        '리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다.  ',
     },
   ];
 
   return (
     <>
       <div className='w-full'>
-        <div className='py-[80px] px-[200px] flex flex-row items-center justify-between bg-[#F8F8F8]'>
+        <div className='w-full py-[80px] px-[40px] flex flex-row items-center justify-between bg-[#F8F8F8]'>
           <div className='w-[200px] h-[120px] flex flex-col justify-center items-center'>
             <span className='text-[54px] font-bold'>4.2</span>
             <div className='flex flex-row'>
@@ -62,7 +61,7 @@ export default function MeetingReviews() {
               )}
             </div>
           </div>
-          <div className='w-[300px] h-[110px] flex flex-row gap-3 text-[18px] font-bold items-center justify-center'>
+          <div className='w-[350px] h-[110px] flex flex-row gap-3 text-[18px] font-bold items-center justify-center'>
             <div className='flex flex-col gap-2 items-end'>
               {stisfactionLevel.map((item, idx) => (
                 <span key={idx}>{item}</span>
@@ -90,28 +89,28 @@ export default function MeetingReviews() {
               {reviewDatas.map((reviewData) => (
                 <div
                   key={reviewData.reviewId}
-                  className='p-[20px] h-[195px] border-b-2 border-gray-100'
+                  className='p-[20px] min-h-[150px] border-b-2 border-gray-100'
                 >
                   <div className='flex flex-row items-center'>
-                    <AvatarIcon width={24} height={24} />
-                    <span className='ml-[4px] mr-[24px]'>
-                      {reviewData.userName}
-                    </span>
-                    {Array.from({
-                      length: reviewData.starScore,
-                    }).map((__, index) => (
-                      <StarFillIcon key={index} width={16} height={16} />
-                    ))}
-                    {Array.from({
-                      length: 5 - reviewData.starScore,
-                    }).map((__, index) => (
-                      <StarBlankIcon key={index} width={16} height={16} />
-                    ))}
+                    <div className='flex flex-row items-center border-r-[1px] border-[rgba(0, 0, 0, 0.10)]'>
+                      <AvatarIcon width={24} height={24} />
+                      <span className='ml-1 mr-3'>{reviewData.userName}</span>
+                    </div>
+                    <div className='flex flex-row ml-3'>
+                      {Array.from({
+                        length: reviewData.starScore,
+                      }).map((__, index) => (
+                        <StarFillIcon key={index} width={16} height={16} />
+                      ))}
+                      {Array.from({
+                        length: 5 - reviewData.starScore,
+                      }).map((__, index) => (
+                        <StarBlankIcon key={index} width={16} height={16} />
+                      ))}
+                    </div>
                   </div>
                   <div className='mt-[10px] flex flex-col'>
-                    {/* (희원) 리뷰 더미데이터 사용 -> api로 데이터 받아올 예정 */}
-                    <span>{reviewData.reviewContent}</span>
-                    <span>{reviewData.reviewContent}</span>
+                    {/* TODO (희원) 리뷰 더미데이터 사용 -> api로 데이터 받아올 예정 */}
                     <span>{reviewData.reviewContent}</span>
                     <span>{reviewData.reviewContent}</span>
                   </div>
@@ -121,7 +120,7 @@ export default function MeetingReviews() {
                 </div>
               ))}
             </div>
-            {/* (희원) api 연결 전, alert로 동작확인 -> api 연결해서 데이터 추가로 불러올 예정 */}
+            {/* TODO (희원) api 연결 전, alert로 동작확인 -> api 연결해서 데이터 추가로 불러올 예정 */}
             <button
               className='w-full h-[48px] mt-[36px] text-[22px] font-bold border-[1px] border-[rgba(0, 0, 0, 0.10)]'
               onClick={() => alert('데이터 추가로 불러오기')}

--- a/app/meeting-detail/[meetingsId]/_components/MeetingsDetails.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/MeetingsDetails.tsx
@@ -6,6 +6,7 @@ import { getMeetingDetails } from '../_lib/meetingDetail';
 import MeetingDetailLeft from './MeetingDetailLeft';
 import MeetingDetailRight from './MeetingDetailRight';
 import MeetingDetailTabs from './MeetingDetailTabs';
+import PageLocator from './PageLocator';
 
 interface MeetingDetailsProps {
   gatheringId: number;
@@ -28,12 +29,17 @@ const MeetingDetails = ({ gatheringId }: MeetingDetailsProps) => {
     );
 
   return (
-    <div className='flex flex-col items-center justify-start mt-[131px] w-[1060px] h-[2000px] mb-20 mx-auto '>
-      <div className='w-full h-[670px] flex flex-row justify-between'>
-        <MeetingDetailLeft data={data.result} />
-        <MeetingDetailRight data={data.result} />
+    <div className='flex flex-col mt-20 w-[1060px] h-[2000px] mb-20 mx-auto'>
+      <PageLocator pagePath={['홈']} currentPage='모임' />
+      <div className='flex flex-row items-start justify-between mt-2'>
+        <div className='w-[337px] sticky top-10'>
+          <MeetingDetailLeft data={data.result} />
+        </div>
+        <div className='w-[654px] flex flex-col'>
+          <MeetingDetailRight data={data.result} />
+          <MeetingDetailTabs gatheringId={gatheringId} />
+        </div>
       </div>
-      <MeetingDetailTabs gatheringId={gatheringId} />
     </div>
   );
 };

--- a/app/meeting-detail/[meetingsId]/_components/PageLocator.tsx
+++ b/app/meeting-detail/[meetingsId]/_components/PageLocator.tsx
@@ -1,0 +1,23 @@
+import ChevronRight from '@/public/ChevronRight';
+import HomeIcon from '@/public/HomeIcon';
+
+interface PageLocatorProps {
+  pagePath: string[];
+  currentPage: string;
+}
+
+const PageLocator = ({ pagePath, currentPage }: PageLocatorProps) => {
+  return (
+    <div className='flex flex-row justify-start items-center text-sm font-medium'>
+      <HomeIcon width={14} height={14} className='mr-2' />
+      {pagePath.map((item, idx) => (
+        <div key={idx} className='flex flex-row justify-start items-center'>
+          <span>{item}</span>
+          <ChevronRight width={14} height={14} />
+        </div>
+      ))}
+      <span>{currentPage}</span>
+    </div>
+  );
+};
+export default PageLocator;

--- a/public/BookIcon.tsx
+++ b/public/BookIcon.tsx
@@ -1,31 +1,10 @@
-interface BookIconProps{
-  width: number;
-  height: number;
-}
-
-const BookIcon = ({width, height}:BookIconProps) => {
+export default function BookIcon (props: React.SVGProps<SVGSVGElement>) {
   return (
-    <>
-      <svg width={`${width}px`} height={`${height}px`} viewBox="0 0 21 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <g clipPath="url(#clip0_776_1156)">
-        <path d="M3.48639 3.77332H6.9721C7.58842 3.77332 8.17949 4.01814 8.61528 4.45394C9.05108 4.88974 9.29591 5.48081 9.29591 6.09712V14.2305C9.29591 13.7682 9.11229 13.3249 8.78544 12.9981C8.45859 12.6712 8.01529 12.4876 7.55306 12.4876H3.48639V3.77332Z" stroke="black" strokeWidth="1.1619" strokeLinecap="round" strokeLinejoin="round"/>
-        <path d="M15.1045 3.77332H11.6188C11.0025 3.77332 10.4114 4.01814 9.97561 4.45394C9.53981 4.88974 9.29498 5.48081 9.29498 6.09712V14.2305C9.29498 13.7682 9.4786 13.3249 9.80545 12.9981C10.1323 12.6712 10.5756 12.4876 11.0378 12.4876H15.1045V3.77332Z" stroke="black" strokeWidth="1.1619" strokeLinecap="round" strokeLinejoin="round"/>
-        <g clipPath="url(#clip1_776_1156)">
-        <rect width="8.71428" height="8.71428" transform="translate(10.457 8.42163)" fill="white"/>
-        <path d="M14.8142 16.4083C16.8196 16.4083 18.4452 14.7827 18.4452 12.7774C18.4452 10.7721 16.8196 9.14642 14.8142 9.14642C12.8089 9.14642 11.1833 10.7721 11.1833 12.7774C11.1833 14.7827 12.8089 16.4083 14.8142 16.4083Z" stroke="black" strokeWidth="0.726191" strokeLinecap="round" strokeLinejoin="round"/>
-        <path d="M14.8143 10.5981V12.7767L16.2667 13.5028" stroke="black" strokeWidth="0.726191" strokeLinecap="round" strokeLinejoin="round"/>
-        </g>
-        </g>
-        <defs>
-        <clipPath id="clip0_776_1156">
-        <rect width="20.3333" height="17.4286" fill="white" transform="translate(0 0.285706)"/>
-        </clipPath>
-        <clipPath id="clip1_776_1156">
-        <rect width="8.71428" height="8.71428" fill="white" transform="translate(10.457 8.42163)"/>
-        </clipPath>
-        </defs>
-      </svg>
-    </>
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
+    <path d="M1.33398 2.60004H5.13397C5.80585 2.60004 6.45022 2.86694 6.92531 3.34203C7.4004 3.81712 7.6673 4.46148 7.6673 5.13336V14C7.6673 13.4961 7.46712 13.0128 7.11081 12.6565C6.75449 12.3002 6.27122 12.1 5.76731 12.1H1.33398V2.60004Z" stroke="black" stroke-width="1.33" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M13.9997 7.99847L14 2.60004H10.2C9.52813 2.60004 8.88377 2.86694 8.40868 3.34203C7.93359 3.81712 7.66669 4.46148 7.66669 5.13336V14C7.66669 13.4961 7.86686 13.0128 8.22318 12.6565C8.28992 12.5898 8.54561 12.3749 8.74558 12.2086" stroke="black" stroke-width="1.33" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M12.5 14C13.8807 14 15 12.8807 15 11.5C15 10.1193 13.8807 9 12.5 9C11.1193 9 10 10.1193 10 11.5C10 12.8807 11.1193 14 12.5 14Z" stroke="black" stroke-width="0.8" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M12.5 10.25V11.5L13.3333 11.9167" stroke="black" stroke-width="0.6" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>
   );
 }
-export default BookIcon

--- a/public/ChevronRight.tsx
+++ b/public/ChevronRight.tsx
@@ -1,0 +1,7 @@
+export default function ChevronRight(props: React.SVGProps<SVGSVGElement>){
+  return (
+    <svg {...props} viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M5.25 10.5L8.75 7L5.25 3.5" stroke="black" stroke-width="1.16667" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  );
+}

--- a/public/ChevronUpIcon.tsx
+++ b/public/ChevronUpIcon.tsx
@@ -1,0 +1,7 @@
+export default function ChevronUpIcon (props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...props} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M18 15L12 9L6 15" stroke="black" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+}

--- a/public/HomeIcon.tsx
+++ b/public/HomeIcon.tsx
@@ -1,0 +1,8 @@
+export default function HomeIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+      <svg {...props} viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M1.75 5.25033L7 1.16699L12.25 5.25033V11.667C12.25 11.9764 12.1271 12.2732 11.9083 12.492C11.6895 12.7107 11.3928 12.8337 11.0833 12.8337H2.91667C2.60725 12.8337 2.3105 12.7107 2.09171 12.492C1.87292 12.2732 1.75 11.9764 1.75 11.667V5.25033Z" stroke="black" stroke-width="1.16667" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M5.25 12.8333V7H8.75V12.8333" stroke="black" stroke-width="1.16667" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+  );
+}

--- a/public/InfoIcon.tsx
+++ b/public/InfoIcon.tsx
@@ -1,0 +1,9 @@
+export default function InfoIcon (props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 15 14" fill="none">
+      <path d="M7.50008 12.8337C10.7217 12.8337 13.3334 10.222 13.3334 7.00033C13.3334 3.77866 10.7217 1.16699 7.50008 1.16699C4.27842 1.16699 1.66675 3.77866 1.66675 7.00033C1.66675 10.222 4.27842 12.8337 7.50008 12.8337Z" stroke="black" stroke-width="1.16667" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M7.5 9.33333V7" stroke="black" stroke-width="1.16667" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M7.5 4.66699H7.50667" stroke="black" stroke-width="1.16667" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  );
+}

--- a/public/MeetingOwnerIcon.tsx
+++ b/public/MeetingOwnerIcon.tsx
@@ -1,0 +1,15 @@
+export default function MeetingOwnerIcon (props: React.SVGProps<SVGSVGElement>) {
+  return (
+      <svg xmlns="http://www.w3.org/2000/svg" {...props} viewBox="0 0 16 16" fill="none">
+        <g clip-path="url(#clip0_852_2086)">
+          <path d="M7.99992 10.0003C10.5772 10.0003 12.6666 7.91099 12.6666 5.33366C12.6666 2.75633 10.5772 0.666992 7.99992 0.666992C5.42259 0.666992 3.33325 2.75633 3.33325 5.33366C3.33325 7.91099 5.42259 10.0003 7.99992 10.0003Z" stroke="black" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+          <path d="M5.47341 9.26155L4.66675 15.3349L8.00008 13.3349L11.3334 15.3349L10.5267 9.25488" stroke="black" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+        </g>
+        <defs>
+          <clipPath id="clip0_852_2086">
+            <rect width="16" height="16" fill="white"/>
+          </clipPath>
+        </defs>
+      </svg>
+  );
+}

--- a/public/StarFillIcon.tsx
+++ b/public/StarFillIcon.tsx
@@ -1,14 +1,8 @@
-interface starFillProps {
-  width: number;
-  height: number;
-}
-
-const StarFill = ({ width, height }: starFillProps) => {
+export default function StarFill(props: React.SVGProps<SVGSVGElement>) {
   return (
     <>
       <svg
-        width={`${width}px`}
-        height={`${height}px`}
+        {...props}
         viewBox='0 0 37 36'
         fill='none'
         xmlns='http://www.w3.org/2000/svg'
@@ -17,13 +11,11 @@ const StarFill = ({ width, height }: starFillProps) => {
           d='M18.1558 3.00098L22.7908 12.391L33.1558 13.906L25.6558 21.211L27.4258 31.531L18.1558 26.656L8.88576 31.531L10.6558 21.211L3.15576 13.906L13.5208 12.391L18.1558 3.00098Z'
           fill='black'
           stroke='black'
-          stroke-width='3.15625'
-          stroke-linecap='round'
-          stroke-linejoin='round'
+          strokeWidth='3.15625'
+          strokeLinecap='round'
+          strokeLinejoin='round'
         />
       </svg>
     </>
   );
 };
-
-export default StarFill;


### PR DESCRIPTION
##  🧲 Pull Request

## #️⃣ 연관된 이슈
#82

## 📝 작업 내용
> 와이어프레임에서 업데이트된 모음 상세페이지를 프로젝트에 적용하였습니다.
### 모임 상세페이지 UI 업데이트 

![20241226_112931](https://github.com/user-attachments/assets/90a9882a-95f1-4372-9c4d-7f1ee8794f83)
- 모임 상세페이지 헤더 좌측 UI 업데이트
  - 페이지 로케이터 구현 및 적용
    - 다른페이지에서 사용되지 않는것으로 확인되었으나 재사용성을 고려하여 별도의 컴포넌트로 구현
    - app\meeting-detail\[meetingsId]\_components\PageLocator.tsx
  - 유저 닉네임 옆 모임장 마크 추가
  - 참여 안내문구 추가
  - 해당 파트가 스크롤해도 화면에 보여질 수 있도록 sticky하도록 스타일 적용

<br />

![image](https://github.com/user-attachments/assets/08a09444-cf0c-46c4-8d64-d3a1ec50a66c)
- 모임 상세페이지 헤더 우측 UI 업데이트
  - 크기가 맞지 않는 일부 아이콘 수정
  - 인원수가 어떤 인원수인지 구분할 수 있도록 '참여', '정원' 추가
  - 시작일과 종료일 사이에 디바이더 추가
  - 독서 리뷰 보러가기를 '함께 읽을 책' 영역 내부로 이동

<br />

![image](https://github.com/user-attachments/assets/57219b12-7a82-4769-bfc0-bcfbcc1cea74)
![image](https://github.com/user-attachments/assets/99ffd8d5-4521-41bd-b16c-1089ca4180d8)
- 모임 상세페이지 모임 소개 > 책 소개 파트 UI 업데이트
  - 책 소개 우측에 툴팁을 띄워줄 'InfoIcon' 아이콘을 추가 
    ( 호버링시 툴팁이 보여지도록 할 예정인데 다른 브랜치에서 작업할 예정 )
  - 책 소개 더보기, 접어두기 UI 업데이트 ( 아이콘 추가, 테스트 변경 )

<br />

![image](https://github.com/user-attachments/assets/c0549bc2-1916-4c5a-8369-3749dcd2a9d8)
- 모임 상세페이지 모임 후기 UI 업데이트
  - UI업데이트로 인해 레이아웃이 깨지는 현상이 있어서 일부 수정



## 🔢 리뷰 요구사항 (선택)
> 코드리뷰시 특별히 봐주었으면 하는 부분 작성

## 🖼️ 스크린샷 (선택)
>
