### PR TITLE
Feat/login,logout 로그인후 전역적으로 유저정보 관리 추가 및 로그아웃 기능 추가 및 적용

### DIFF
--- a/app/_utils/logout.ts
+++ b/app/_utils/logout.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import useUserStore from '@/store/userStore';
+import Cookies from 'js-cookie';
+import { useRouter } from 'next/navigation';
+
+export const Logout = () => {
+  const router = useRouter();
+  const clearUser = useUserStore((state) => state.clearUser);
+
+  const clearAndRedirect = () => {
+    clearUser();
+    Cookies.remove('token');
+    router.push('/');
+  };
+
+  return clearAndRedirect;
+};

--- a/app/auth/login/_components/login-form.tsx
+++ b/app/auth/login/_components/login-form.tsx
@@ -1,28 +1,54 @@
 'use client';
 
-import { useFormState } from 'react-dom';
+import { useState } from 'react';
 import { FormButton } from '../../_components/form-button';
 import { userLogIn } from '../_lib/login';
 import { LoginFormInput } from './login-form-input';
+import useUserStore from '@/store/userStore';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 export const LoginForm = () => {
-  const initialState = { message: '', errors: {} };
-  const [state, dispatch] = useFormState(userLogIn, initialState);
+  const { setUser } = useUserStore();
+  const [state, setState] = useState({ message: '', errors: {} });
+  const router = useRouter();
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    try {
+      const result = await userLogIn(formData);
+      console.log(result);
+
+      if (result.errors) {
+        setState({ message: result.message, errors: result.errors });
+      } else if (result.user) {
+        setUser(result.user);
+        router.push('/');
+      } else if (result.message) {
+        setState({ message: result.message, errors: {} });
+      }
+    } catch (error) {
+      console.error('Unexpected error:', error);
+      setState({ message: '예상치 못한 오류가 발생했습니다.', errors: {} });
+    }
+  };
+
   return (
-    <form action={dispatch} className='max-w-[380px]'>
+    <form onSubmit={handleSubmit} className='max-w-[380px]'>
       <div className='flex flex-col space-y-2'>
-        <LoginFormInput errors={state?.errors} />
+        <LoginFormInput errors={state.errors} />
         <div className='h-6'>
-          {state?.message && (
+          {state.message && (
             <p className='text-sm text-error'>{state.message}</p>
           )}
         </div>
       </div>
       <div className='flex flex-col mt-[32px] gap-5'>
         <FormButton
-          className='w-full h-12 p-2.5 text-base font-bold bg-black text-white rounded'
           disabled={false}
+          className='w-full h-12 p-2.5 text-base font-bold bg-black text-white rounded'
         >
           로그인
         </FormButton>

--- a/app/auth/login/_lib/login.ts
+++ b/app/auth/login/_lib/login.ts
@@ -3,18 +3,21 @@
 import { setCookie } from '../../_utils/cookie';
 import { validateLoginData } from './login-validation';
 import { fetchAPIServer } from '@/lib/fetchAPI.server';
-import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
 
-export type State = {
-  error?: {
+export async function userLogIn(formData: FormData): Promise<{
+  user?: {
+    id: number;
+    name: string;
+    email: string;
+    profile: string | null;
+    roles: string;
+  };
+  errors?: {
     email?: string[];
     password?: string[];
   };
-  message: string | null;
-};
-
-export async function userLogIn(prevState: State, formData: FormData) {
+  message: string;
+}> {
   const validationResult = validateLoginData(formData);
 
   if (!validationResult.success) {
@@ -31,7 +34,6 @@ export async function userLogIn(prevState: State, formData: FormData) {
     password,
   });
 
-  console.log('test:', response);
   if (response.status !== 200) {
     try {
       const errorMessage = response.error?.message || '{}';
@@ -50,18 +52,36 @@ export async function userLogIn(prevState: State, formData: FormData) {
         message: translatedMessage,
       };
     } catch (e) {
-      console.error('JSON 파싱 오류:', e);
+      const errorMsg = e instanceof Error ? e.message : '알 수 없는 오류';
       return {
-        message: '로그인 실패: 알 수 없는 오류가 발생했습니다.',
+        message: `로그인 실패: ${errorMsg}`,
       };
     }
-  } else {
-    setCookie('token', response.result.token, {
-      httpOnly: false,
-      secure: true,
-      maxAge: 60 * 60 * 24 * 1,
-    });
-    revalidatePath('/');
-    redirect('/');
   }
+
+  const {
+    usersId,
+    userName,
+    email: userEmail,
+    profile,
+    roles,
+    token,
+  } = response.result;
+
+  setCookie('token', token, {
+    httpOnly: false,
+    secure: true,
+    maxAge: 60 * 60 * 24, // 1 day
+  });
+
+  return {
+    user: {
+      id: usersId,
+      name: userName,
+      email: userEmail,
+      profile,
+      roles,
+    },
+    message: '',
+  };
 }

--- a/app/mypage/_components/Sidebar.tsx
+++ b/app/mypage/_components/Sidebar.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { Logout } from '@/app/_utils/logout';
 import Link from 'next/link';
 import { useSelectedLayoutSegment } from 'next/navigation';
 
 export default function Sidebar() {
   const segment = useSelectedLayoutSegment();
+  const HandleLogout = Logout();
 
   return (
     <ul className='flex flex-col gap-10 w-[253px] h-[790px] border pl-[41px] pt-[33px] pr-6 text-xl'>
@@ -32,7 +34,10 @@ export default function Sidebar() {
           나의 리뷰
         </Link>
       </li>
-      <li className='w-[188px] opacity-50 hover:bg-[#D9D9D9] hover:bg-opacity-30 p-3 leading-normal cursor-pointer'>
+      <li
+        onClick={HandleLogout}
+        className='w-[188px] opacity-50 hover:bg-[#D9D9D9] hover:bg-opacity-30 p-3 leading-normal cursor-pointer'
+      >
         로그아웃
       </li>
     </ul>

--- a/components/GNB.tsx
+++ b/components/GNB.tsx
@@ -9,6 +9,8 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { fetchAPIClient } from '@/lib/fetchAPI.client';
 import Logo from '@/public/Logo';
+import useUserStore, { UserProps } from '@/store/userStore';
+import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
@@ -16,9 +18,9 @@ const GNB = () => {
   const pathname = usePathname();
   const isAuthPage = pathname === '/auth/signup';
   const isSearchPage = pathname === '/search';
-
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [loading, setLoading] = useState(true);
+  const user = useUserStore((state) => state.user);
 
   useEffect(() => {
     const checkLoginStatus = async () => {
@@ -60,7 +62,7 @@ const GNB = () => {
         />
       </div>
       {isLoggedIn ? (
-        <LoggedInMenu isSearchPage={isSearchPage} />
+        <LoggedInMenu user={user} isSearchPage={isSearchPage} />
       ) : (
         <LoggedOutMenu isSearchPage={isSearchPage} />
       )}
@@ -85,13 +87,18 @@ const NavButton = ({
         ? 'pointer-events-none after:absolute after:bottom-0 after:left-0 after:h-[2px] after:w-full after:bg-customGrey-800'
         : ''
     }`}
-    disabled={active}
   >
     <Link href={href}>{label}</Link>
   </Button>
 );
 
-const LoggedInMenu = ({ isSearchPage }: { isSearchPage: boolean }) => (
+const LoggedInMenu = ({
+  user,
+  isSearchPage,
+}: {
+  user: UserProps | null;
+  isSearchPage: boolean;
+}) => (
   <div className='flex items-center gap-6'>
     {!isSearchPage && <SearchBar />}
     <Link href='/mypage/meetings'>
@@ -99,7 +106,17 @@ const LoggedInMenu = ({ isSearchPage }: { isSearchPage: boolean }) => (
     </Link>
     <BellIcon className='h-7 w-7' />
     <Link href='/mypage'>
-      <Avatar width={32} height={32} />
+      {user?.profile ? (
+        <Image
+          src={user.profile}
+          alt='User Profile'
+          width={32}
+          height={32}
+          className='rounded-full'
+        />
+      ) : (
+        <Avatar width={32} height={32} />
+      )}
     </Link>
     <Button
       asChild

--- a/store/userStore.ts
+++ b/store/userStore.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+export interface UserProps {
+  id: number;
+  name: string;
+  profile: string | null;
+  email: string;
+  roles: string;
+}
+
+interface UserState {
+  user: UserProps | null;
+  setUser: (userData: UserProps) => void;
+  clearUser: () => void;
+}
+
+const useUserStore = create<UserState>()(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (userData) => {
+        set({ user: userData });
+      },
+      clearUser: () => {
+        set({ user: null });
+      },
+    }),
+    {
+      name: 'user-store',
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);
+
+export default useUserStore;


### PR DESCRIPTION
##  🧲 Pull Request

## #️⃣ 연관된 이슈

> #90 

## 📝 작업 내용
### 로그인 후 전역으로 유저 정보 저장.
### 로그아웃 유틸함수 생성 후 로그아웃 버튼에 적용



### 사용예시
```
'use client';

import useUserStore, { UserProps } from '@/store/userStore';

const UserDetails = () => {
  const user: UserProps | null = useUserStore((state) => state.user);

  if (!user) return <p>No user is logged in.</p>;

  return (
    <div className="p-4 border rounded">
      <h1 className="font-bold">User Details</h1>
      <p>ID: {user.id}</p>
      <p>Name: {user.name}</p>
      <p>Email: {user.email}</p>
      <p>Roles: {user.roles}</p>
      {user.profile ? (
        <img src={user.profile} alt="Profile" className="w-16 h-16 rounded-full" />
      ) : (
        <p>No profile image available</p>
      )}
    </div>
  );
};

export default UserDetails;
```

## 🔢 리뷰 요구사항 (선택)
>

## 🖼️ 스크린샷 (선택)
>
