### PR TITLE
Feat/review-detail 리뷰 상세 페이지 정보 불러오기

### DIFF
--- a/app/mypage/meetings/_components/MeetingList.tsx
+++ b/app/mypage/meetings/_components/MeetingList.tsx
@@ -2,8 +2,8 @@
 
 import { useState } from 'react';
 import Meeting from './Meeting';
-import Pagination from './Pagination';
 import { useTabContext } from './TabContext';
+import Pagination from '@/components/Pagination';
 import { useMyMeetingCountQuery } from '@/hooks/useMyMeetingCountQuery';
 import { useMyMeetingQuery } from '@/hooks/useMyMeetingQuery';
 import { MyMeetingCount } from '@/types/meeting';
@@ -36,7 +36,12 @@ export default function MeetingList() {
           <Meeting key={meeting.id} meeting={meeting} />
         ))}
       </div>
-      <Pagination page={page} totalPage={totalPage} onPageChange={setPage} />
+      <Pagination
+        page={page}
+        totalPage={totalPage}
+        onPageChange={setPage}
+        className='flex justify-center gap-2 mt-20 absolute bottom-10 left-1/3'
+      />
     </div>
   );
 }

--- a/app/reviews/[id]/_components/BookReviewList.tsx
+++ b/app/reviews/[id]/_components/BookReviewList.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { getBookReviews } from '../_lib/getBookReviews';
+import ReviewCard from './ReviewCard';
+
+export default function BookReviewList({ title }: { title?: string }) {
+  const { data: reviews } = useQuery({
+    queryKey: ['reviews', 'book', title, 0],
+    queryFn: () => getBookReviews(title as string, 0),
+    enabled: !!title,
+    staleTime: 60 * 1000,
+  });
+
+  return (
+    <aside className='relative w-[343px] h-[590px] px-7 py-5 border'>
+      <p className='text-sm font-bold'>
+        <span className='text-customGreen-500'>{title}</span>의 리뷰 모아보기
+      </p>
+      <ul className='w-full h-[498px]'>
+        {reviews?.bookReviews.map((review, i) => (
+          <ReviewCard key={i} review={review} />
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/app/reviews/[id]/_components/BookReviewList.tsx
+++ b/app/reviews/[id]/_components/BookReviewList.tsx
@@ -1,16 +1,22 @@
 'use client';
 
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getBookReviews } from '../_lib/getBookReviews';
 import ReviewCard from './ReviewCard';
+import Pagination from '@/components/Pagination';
+
+const SIZE = 3;
 
 export default function BookReviewList({ title }: { title?: string }) {
+  const [page, setPage] = useState(0);
   const { data: reviews } = useQuery({
-    queryKey: ['reviews', 'book', title, 0],
-    queryFn: () => getBookReviews(title as string, 0),
+    queryKey: ['reviews', 'book', title, page],
+    queryFn: () => getBookReviews(title as string, page),
     enabled: !!title,
     staleTime: 60 * 1000,
   });
+  const totalPage = Math.ceil((reviews?.total || 0) / SIZE);
 
   return (
     <aside className='relative w-[343px] h-[590px] px-7 py-5 border'>
@@ -19,9 +25,16 @@ export default function BookReviewList({ title }: { title?: string }) {
       </p>
       <ul className='w-full h-[498px]'>
         {reviews?.bookReviews.map((review, i) => (
+          // TODO (유진) key 부분 review.id로 변경할 것
           <ReviewCard key={i} review={review} />
         ))}
       </ul>
+      <Pagination
+        page={page}
+        totalPage={totalPage}
+        onPageChange={setPage}
+        className='flex items-center justify-center mt-2.5'
+      />
     </aside>
   );
 }

--- a/app/reviews/[id]/_components/CommentList.tsx
+++ b/app/reviews/[id]/_components/CommentList.tsx
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query';
+import { getReviewDetail } from '../_lib/getReviewDetail';
+import Avatar from '@/components/common/icons/Avatar';
+import Image from 'next/image';
+import { useParams } from 'next/navigation';
+
+export default function CommentList() {
+  const { id } = useParams();
+  const { data: review } = useQuery({
+    queryKey: ['reviews', 'detail', id],
+    queryFn: () => getReviewDetail(Number(id)),
+    staleTime: 60 * 1000,
+  });
+
+  return (
+    <div className='pt-5 border-t'>
+      <div className='flex flex-col gap-3'>
+        <h3 className='text-lg font-bold'>
+          댓글 {review?.commentList?.length}
+        </h3>
+        <div className='flex flex-col gap-3 border p-5 rounded-sm'>
+          <div className='flex gap-2'>
+            <div className='w-8 h-8 bg-[#D9D9D9] rounded-full'></div>
+            <p>jenny</p>
+          </div>
+          <input
+            type='text'
+            className='w-full mb-2.5 placeholder-customGrey-300'
+            placeholder='리뷰에 대한 댓글을 남겨보세요'
+          />
+          <button className='ml-auto px-3 py-2 bg-customGrey-100 text-customGrey-300 rounded-sm'>
+            댓글 작성
+          </button>
+        </div>
+      </div>
+      <ul>
+        {review?.commentList?.map(
+          ({ id, userName, content, profile, createTime }) => (
+            <li key={id} className='py-4 border-b last:border-none'>
+              <div className='flex gap-2'>
+                {profile ? (
+                  <Image src={profile} width={32} height={32} alt='프로필' />
+                ) : (
+                  <Avatar className='w-8 h-8' />
+                )}
+                <p>{userName}</p>
+              </div>
+              <div className='flex flex-col gap-2.5 ml-10'>
+                {content}
+                <p className='text-customGrey-300'>{createTime}</p>
+              </div>
+            </li>
+          ),
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/app/reviews/[id]/_components/ReviewCard.tsx
+++ b/app/reviews/[id]/_components/ReviewCard.tsx
@@ -1,0 +1,23 @@
+import CommentIcon from '@/app/reviews/_svg/CommentIcon';
+import LikeIcon from '@/app/reviews/_svg/LikeIcon';
+import { BookReviewByTitle } from '@/types/book';
+
+export default function ReviewCard({ review }: { review: BookReviewByTitle }) {
+  const { title, content, likes, commentCnt, userLikeCk } = review;
+  return (
+    <div className='flex flex-col gap-2 py-5 border-b'>
+      <h3 className='font-bold'>{title}</h3>
+      <div className='w-[287px] h-12 line-clamp-2'>{content}</div>
+      <div className='flex gap-5 mt-2'>
+        <div className='flex gap-1'>
+          <LikeIcon className={`w-5 h-5 ${userLikeCk ? 'fill-black' : ''}`} />
+          <p>{likes}</p>
+        </div>
+        <div className='flex items-center gap-1'>
+          <CommentIcon className='w-5 h-5' />
+          <p>{commentCnt || 0}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/reviews/[id]/_components/ReviewCard.tsx
+++ b/app/reviews/[id]/_components/ReviewCard.tsx
@@ -1,16 +1,29 @@
 import CommentIcon from '@/app/reviews/_svg/CommentIcon';
 import LikeIcon from '@/app/reviews/_svg/LikeIcon';
+import { useReviewLikeQuery } from '@/hooks/useReviewLikeQuery';
 import { BookReviewByTitle } from '@/types/book';
 
 export default function ReviewCard({ review }: { review: BookReviewByTitle }) {
+  const { likeMutation, unlikeMutation } = useReviewLikeQuery(review.id);
   const { title, content, likes, commentCnt, userLikeCk } = review;
+
+  const handleLike = () => {
+    if (userLikeCk) {
+      unlikeMutation();
+    } else {
+      likeMutation();
+    }
+  };
+
   return (
     <li className='flex flex-col gap-2 py-5 border-b'>
       <h3 className='font-bold'>{title}</h3>
       <div className='w-[287px] h-12 line-clamp-2'>{content}</div>
       <div className='flex gap-5 mt-2'>
         <div className='flex gap-1'>
-          <LikeIcon className={`w-5 h-5 ${userLikeCk ? 'fill-black' : ''}`} />
+          <button onClick={handleLike}>
+            <LikeIcon className={`w-5 h-5 ${userLikeCk ? 'fill-black' : ''}`} />
+          </button>
           <p>{likes}</p>
         </div>
         <div className='flex items-center gap-1'>

--- a/app/reviews/[id]/_components/ReviewCard.tsx
+++ b/app/reviews/[id]/_components/ReviewCard.tsx
@@ -5,7 +5,7 @@ import { BookReviewByTitle } from '@/types/book';
 export default function ReviewCard({ review }: { review: BookReviewByTitle }) {
   const { title, content, likes, commentCnt, userLikeCk } = review;
   return (
-    <div className='flex flex-col gap-2 py-5 border-b'>
+    <li className='flex flex-col gap-2 py-5 border-b'>
       <h3 className='font-bold'>{title}</h3>
       <div className='w-[287px] h-12 line-clamp-2'>{content}</div>
       <div className='flex gap-5 mt-2'>
@@ -18,6 +18,6 @@ export default function ReviewCard({ review }: { review: BookReviewByTitle }) {
           <p>{commentCnt || 0}</p>
         </div>
       </div>
-    </div>
+    </li>
   );
 }

--- a/app/reviews/[id]/_components/ReviewDetail.tsx
+++ b/app/reviews/[id]/_components/ReviewDetail.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { ReviewDetailResponse, getReviewDetail } from '../_lib/getReviewDetail';
+import CommentList from './CommentList';
+import ReviewTag from './ReviewTag';
+import CommentIcon from '@/app/reviews/_svg/CommentIcon';
+import LikeIcon from '@/app/reviews/_svg/LikeIcon';
+import MoreIcon from '@/components/common/icons/MoreIcon';
+import { BookDetail, BookReviewDetail } from '@/types/book';
+import Image from 'next/image';
+import { useParams } from 'next/navigation';
+
+export default function ReviewDetail() {
+  const { id } = useParams();
+  const { data: review } = useQuery<ReviewDetailResponse>({
+    queryKey: ['reviews', 'detail', id],
+    queryFn: () => getReviewDetail(Number(id)),
+    staleTime: 60 * 1000,
+  });
+  if (!review) return null;
+  const { bookReview, bookResponse, commentList } = review;
+  const {
+    title: reviewTitle,
+    content,
+    apprCd,
+    tagCd,
+    likes,
+    createTime,
+    userName,
+    userLikeCk,
+  } = bookReview as BookReviewDetail;
+  const {
+    title,
+    author,
+    image,
+    publisher,
+    publisherDate,
+    star,
+    gatheringExists,
+  } = bookResponse as BookDetail;
+  return (
+    <section className='w-[700px] mt-[60px] ml-[190px]'>
+      <div className='px-[30px] pt-8'>
+        <div className='pb-5 border-b'>
+          <h2 className='text-[32px] font-bold mb-4'>{reviewTitle}</h2>
+          <div className='flex justify-between'>
+            <div className='flex items-center gap-2.5'>
+              <div className='w-6 h-6 bg-[#D9D9D9] rounded-full'></div>
+              <p className='font-bold'>{userName}</p>
+              <p className='text-sm text-customGrey-300'>
+                {createTime.replace(/-/g, '.')}
+              </p>
+            </div>
+            <button>
+              <MoreIcon className='w-6 h-6 stroke-customGrey-300' />
+            </button>
+          </div>
+        </div>
+        <div className='flex flex-col gap-8 px-7.5 py-5'>
+          <div className='text-lg w-[535px]'>{content}</div>
+          <div className='border p-4 rounded-sm'>
+            <div className='flex gap-2.5 mb-2.5'>
+              <Image src={image} width={95} height={140} alt='책 표지' />
+              <div>
+                <h3 className='mb-2'>{title}</h3>
+                <p className='text-customGrey-500'>
+                  저자 <span className='text-customGrey-800'>{author}</span>
+                </p>
+                <p className='text-customGrey-500'>
+                  출판 <span className='text-customGrey-800'>{publisher}</span>
+                </p>
+                <p className='text-customGrey-500'>
+                  발행일{' '}
+                  <span className='text-customGrey-800'>{publisherDate}</span>
+                </p>
+                <p className='text-customGrey-500'>
+                  평점 <span className='text-customGrey-800'>{star}</span>
+                </p>
+              </div>
+            </div>
+            {gatheringExists && (
+              <div className='flex justify-between items-center w-full h-14 bg-customGrey-50 p-2 rounded-[2px]'>
+                <p className='text-customGrey-800'>
+                  현재 모집 중인 모임이 있어요.
+                </p>
+                <button className='px-3 py-2 bg-customGreen-50 text-customGreen-600 rounded-sm'>
+                  보러 가기
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+        <div>
+          {apprCd === 'SG' ? (
+            <p className='text-customGrey-500 mb-1.5'>이 책을 추천해요</p>
+          ) : apprCd === 'NG' ? (
+            <p className='text-customGrey-500 mb-1.5'>
+              이 책은 아쉬운 부분이 있었어요
+            </p>
+          ) : null}
+          <ReviewTag tag={tagCd} />
+        </div>
+        <div className='flex gap-5 mt-6 mb-5'>
+          <div className='flex gap-1'>
+            <LikeIcon className={`w-5 h-5 ${userLikeCk ? 'fill-black' : ''}`} />
+            <span>{likes}</span>
+          </div>
+          <div className='flex items-center gap-1'>
+            <CommentIcon className='w-5 h-5' />
+            {commentList?.length || 0}
+          </div>
+        </div>
+        <CommentList />
+      </div>
+    </section>
+  );
+}

--- a/app/reviews/[id]/_components/ReviewDetail.tsx
+++ b/app/reviews/[id]/_components/ReviewDetail.tsx
@@ -7,6 +7,7 @@ import ReviewTag from './ReviewTag';
 import CommentIcon from '@/app/reviews/_svg/CommentIcon';
 import LikeIcon from '@/app/reviews/_svg/LikeIcon';
 import MoreIcon from '@/components/common/icons/MoreIcon';
+import { useReviewLikeQuery } from '@/hooks/useReviewLikeQuery';
 import { BookDetail, BookReviewDetail } from '@/types/book';
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
@@ -18,6 +19,7 @@ export default function ReviewDetail() {
     queryFn: () => getReviewDetail(Number(id)),
     staleTime: 60 * 1000,
   });
+  const { likeMutation, unlikeMutation } = useReviewLikeQuery(Number(id));
   if (!review) return null;
   const { bookReview, bookResponse, commentList } = review;
   const {
@@ -39,6 +41,13 @@ export default function ReviewDetail() {
     star,
     gatheringExists,
   } = bookResponse as BookDetail;
+  const handleLike = () => {
+    if (userLikeCk) {
+      unlikeMutation();
+    } else {
+      likeMutation();
+    }
+  };
   return (
     <section className='w-[700px] ml-[190px]'>
       <div className='px-[30px] pt-8'>
@@ -109,7 +118,11 @@ export default function ReviewDetail() {
         </div>
         <div className='flex gap-5 mt-6 mb-5'>
           <div className='flex gap-1'>
-            <LikeIcon className={`w-5 h-5 ${userLikeCk ? 'fill-black' : ''}`} />
+            <button onClick={handleLike}>
+              <LikeIcon
+                className={`w-5 h-5 ${userLikeCk ? 'fill-black' : ''}`}
+              />
+            </button>
             <span>{likes}</span>
           </div>
           <div className='flex items-center gap-1'>

--- a/app/reviews/[id]/_components/ReviewDetail.tsx
+++ b/app/reviews/[id]/_components/ReviewDetail.tsx
@@ -40,7 +40,7 @@ export default function ReviewDetail() {
     gatheringExists,
   } = bookResponse as BookDetail;
   return (
-    <section className='w-[700px] mt-[60px] ml-[190px]'>
+    <section className='w-[700px] ml-[190px]'>
       <div className='px-[30px] pt-8'>
         <div className='pb-5 border-b'>
           <h2 className='text-[32px] font-bold mb-4'>{reviewTitle}</h2>
@@ -61,7 +61,13 @@ export default function ReviewDetail() {
           <div className='text-lg w-[535px]'>{content}</div>
           <div className='border p-4 rounded-sm'>
             <div className='flex gap-2.5 mb-2.5'>
-              <Image src={image} width={95} height={140} alt='책 표지' />
+              <Image
+                src={image}
+                className='w-[95px] h-[140px]'
+                width={95}
+                height={140}
+                alt='책 표지'
+              />
               <div>
                 <h3 className='mb-2'>{title}</h3>
                 <p className='text-customGrey-500'>

--- a/app/reviews/[id]/_components/ReviewTag.tsx
+++ b/app/reviews/[id]/_components/ReviewTag.tsx
@@ -1,0 +1,27 @@
+import { BookReviewTag } from '@/types/book';
+
+const tagMessage = {
+  BAD: '😕 기대 이하였어요',
+  CS: '🤗따뜻한 위로를 받았어요',
+  DP: '😔 결말이 아쉬웠어요',
+  FIND: '🔍 새로운 것을 발견했어요',
+  FUN: '🤩 정말 흥미진진했어요',
+  KL: '📚 유익한 지식을 얻었어요',
+  SAD: '😢 눈물이 날 뻔 했어요',
+  TIME: '⏳ 시간 가는 줄 몰랐어요',
+};
+
+export default function ReviewTag({ tag }: { tag: string }) {
+  const tags = tag.split(',');
+  const messages = tags.map((tag) => tagMessage[tag as BookReviewTag]);
+
+  return (
+    <div className='flex flex-wrap gap-2.5'>
+      {messages?.map((message, i) => (
+        <p key={i} className='h-10 px-2.5 py-1.5 border rounded-sm'>
+          {message}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/app/reviews/[id]/_lib/getBookReviews.ts
+++ b/app/reviews/[id]/_lib/getBookReviews.ts
@@ -1,0 +1,21 @@
+import { fetchAPIClient } from '@/lib/fetchAPI.client';
+import { BookReviewByTitle } from '@/types/book';
+
+const size = 3;
+type BookReviewListResponse = {
+  bookReviews: BookReviewByTitle[];
+  total: number;
+};
+export const getBookReviews = async (
+  title: string,
+  page: number,
+): Promise<BookReviewListResponse> => {
+  const res = await fetchAPIClient(
+    `/api/review/search?type=BOOK_NAME&searchParam=${title}&page=${page}&size=${size}`,
+    'GET',
+  );
+  if (res.code === 'SUCCESS') {
+    return res.result;
+  }
+  throw new Error(`failed to fetch book reviews : ${res.message}`);
+};

--- a/app/reviews/[id]/_lib/getBookReviews.ts
+++ b/app/reviews/[id]/_lib/getBookReviews.ts
@@ -2,7 +2,7 @@ import { fetchAPIClient } from '@/lib/fetchAPI.client';
 import { BookReviewByTitle } from '@/types/book';
 
 const size = 3;
-type BookReviewListResponse = {
+export type BookReviewListResponse = {
   bookReviews: BookReviewByTitle[];
   total: number;
 };

--- a/app/reviews/[id]/_lib/getBookReviewsServer.ts
+++ b/app/reviews/[id]/_lib/getBookReviewsServer.ts
@@ -1,0 +1,21 @@
+import { fetchAPIServer } from '@/lib/fetchAPI.server';
+import { BookReviewByTitle } from '@/types/book';
+
+const size = 3;
+export type BookReviewListResponse = {
+  bookReviews: BookReviewByTitle[];
+  total: number;
+};
+export const getBookReviewsServer = async (
+  page: number,
+  title: string,
+): Promise<BookReviewListResponse> => {
+  const res = await fetchAPIServer(
+    `/api/review/search?type=BOOK_NAME&searchParam=${title}&page=${page}&size=${size}`,
+    'GET',
+  );
+  if (res.code === 'SUCCESS') {
+    return res.result;
+  }
+  throw new Error(`failed to fetch book reviews : ${res.message}`);
+};

--- a/app/reviews/[id]/_lib/getReviewDetail.ts
+++ b/app/reviews/[id]/_lib/getReviewDetail.ts
@@ -3,7 +3,7 @@ import { BookDetail, BookReviewDetail } from '@/types/book';
 import { BookReviewComment } from '@/types/review';
 
 export type ReviewDetailResponse = {
-  bookReview?: BookReviewDetail;
+  bookReview: BookReviewDetail;
   bookResponse: BookDetail;
   commentList?: BookReviewComment[];
 };

--- a/app/reviews/[id]/_lib/getReviewDetail.ts
+++ b/app/reviews/[id]/_lib/getReviewDetail.ts
@@ -1,0 +1,19 @@
+import { fetchAPIClient } from '@/lib/fetchAPI.client';
+import { BookDetail, BookReviewDetail } from '@/types/book';
+import { BookReviewComment } from '@/types/review';
+
+export type ReviewDetailResponse = {
+  bookReview?: BookReviewDetail;
+  bookResponse: BookDetail;
+  commentList?: BookReviewComment[];
+};
+
+export const getReviewDetail = async (
+  id: number,
+): Promise<ReviewDetailResponse> => {
+  const res = await fetchAPIClient(`/api/review/${id}/detail`, 'GET');
+  if (res.code === 'SUCCESS') {
+    return res.result;
+  }
+  throw new Error(`failed to fetch review detail : ${res.message}`);
+};

--- a/app/reviews/[id]/_lib/getReviewDetailServer.ts
+++ b/app/reviews/[id]/_lib/getReviewDetailServer.ts
@@ -1,0 +1,19 @@
+import { fetchAPIServer } from '@/lib/fetchAPI.server';
+import { BookDetail, BookReviewDetail } from '@/types/book';
+import { BookReviewComment } from '@/types/review';
+
+type ReviewDetailResponse = {
+  bookReview?: BookReviewDetail;
+  bookResponse: BookDetail;
+  commentList?: BookReviewComment[];
+};
+
+export const getReviewDetailServer = async (
+  id: number,
+): Promise<ReviewDetailResponse> => {
+  const res = await fetchAPIServer(`/api/review/${id}/detail`, 'GET');
+  if (res.code === 'SUCCESS') {
+    return res.result;
+  }
+  throw new Error(`failed to fetch review detail : ${res.message}`);
+};

--- a/app/reviews/[id]/_lib/getReviewDetailServer.ts
+++ b/app/reviews/[id]/_lib/getReviewDetailServer.ts
@@ -2,7 +2,7 @@ import { fetchAPIServer } from '@/lib/fetchAPI.server';
 import { BookDetail, BookReviewDetail } from '@/types/book';
 import { BookReviewComment } from '@/types/review';
 
-type ReviewDetailResponse = {
+export type ReviewDetailResponse = {
   bookReview?: BookReviewDetail;
   bookResponse: BookDetail;
   commentList?: BookReviewComment[];

--- a/app/reviews/[id]/page.tsx
+++ b/app/reviews/[id]/page.tsx
@@ -3,7 +3,10 @@ import {
   QueryClient,
   dehydrate,
 } from '@tanstack/react-query';
+import BookReviewList from './_components/BookReviewList';
 import ReviewDetail from './_components/ReviewDetail';
+import { getBookReviewsServer } from './_lib/getBookReviewsServer';
+import { ReviewDetailResponse } from './_lib/getReviewDetail';
 import { getReviewDetailServer } from './_lib/getReviewDetailServer';
 
 type Props = { params: { id: number } };
@@ -15,11 +18,27 @@ export default async function ReviewDetailPage({ params }: Props) {
     queryKey: ['reviews', 'detail', id],
     queryFn: () => getReviewDetailServer(id as number),
   });
+  const reviewInfo = queryClient.getQueryData<ReviewDetailResponse>([
+    'reviews',
+    'detail',
+    id,
+  ]);
+  const title = reviewInfo?.bookResponse.title;
+
+  if (title) {
+    await queryClient.prefetchQuery({
+      queryKey: ['reviews', 'book', title, 0],
+      queryFn: () => getBookReviewsServer(0, title),
+    });
+  }
   const dehydrateState = dehydrate(queryClient);
 
   return (
     <HydrationBoundary state={dehydrateState}>
-      <ReviewDetail />
+      <div className='flex gap-[50px] pt-[60px]'>
+        <ReviewDetail />
+        <BookReviewList title={title} />
+      </div>
     </HydrationBoundary>
   );
 }

--- a/app/reviews/[id]/page.tsx
+++ b/app/reviews/[id]/page.tsx
@@ -1,3 +1,25 @@
-export default function ReviewDetailPage() {
-  return <div>독서 리뷰 상세 페이지</div>;
+import {
+  HydrationBoundary,
+  QueryClient,
+  dehydrate,
+} from '@tanstack/react-query';
+import ReviewDetail from './_components/ReviewDetail';
+import { getReviewDetailServer } from './_lib/getReviewDetailServer';
+
+type Props = { params: { id: number } };
+
+export default async function ReviewDetailPage({ params }: Props) {
+  const queryClient = new QueryClient();
+  const { id } = params;
+  await queryClient.prefetchQuery({
+    queryKey: ['reviews', 'detail', id],
+    queryFn: () => getReviewDetailServer(id as number),
+  });
+  const dehydrateState = dehydrate(queryClient);
+
+  return (
+    <HydrationBoundary state={dehydrateState}>
+      <ReviewDetail />
+    </HydrationBoundary>
+  );
 }

--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -1,15 +1,21 @@
 import PageNext from '@/components/common/icons/PageNext';
-import PagePrev from '@/components/common/icons/PageNext';
+import PagePrev from '@/components/common/icons/PagePrev';
 
 type Props = {
   page: number;
   totalPage: number;
   onPageChange: (page: number) => void;
+  className?: string;
 };
 
-export default function Pagination({ page, totalPage, onPageChange }: Props) {
+export default function Pagination({
+  page,
+  totalPage,
+  onPageChange,
+  className,
+}: Props) {
   return (
-    <div className='flex justify-center gap-2 mt-20 absolute bottom-10 left-1/3'>
+    <div className={className}>
       <button onClick={() => onPageChange(page - 1)} disabled={!page}>
         <PagePrev className='w-8 h-8' />
       </button>

--- a/components/common/icons/MoreIcon.tsx
+++ b/components/common/icons/MoreIcon.tsx
@@ -2,27 +2,25 @@ export default function MoreIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       {...props}
+      stroke='currentColor'
       viewBox='0 0 25 25'
       fill='none'
       xmlns='http://www.w3.org/2000/svg'
     >
       <path
         d='M12.4413 13.2493C12.9936 13.2493 13.4413 12.8016 13.4413 12.2493C13.4413 11.697 12.9936 11.2493 12.4413 11.2493C11.889 11.2493 11.4413 11.697 11.4413 12.2493C11.4413 12.8016 11.889 13.2493 12.4413 13.2493Z'
-        stroke='black'
         strokeWidth='2'
         strokeLinecap='round'
         strokeLinejoin='round'
       />
       <path
         d='M19.4413 13.2493C19.9936 13.2493 20.4413 12.8016 20.4413 12.2493C20.4413 11.697 19.9936 11.2493 19.4413 11.2493C18.889 11.2493 18.4413 11.697 18.4413 12.2493C18.4413 12.8016 18.889 13.2493 19.4413 13.2493Z'
-        stroke='black'
         strokeWidth='2'
         strokeLinecap='round'
         strokeLinejoin='round'
       />
       <path
         d='M5.44128 13.2493C5.99357 13.2493 6.44128 12.8016 6.44128 12.2493C6.44128 11.697 5.99357 11.2493 5.44128 11.2493C4.889 11.2493 4.44128 11.697 4.44128 12.2493C4.44128 12.8016 4.889 13.2493 5.44128 13.2493Z'
-        stroke='black'
         strokeWidth='2'
         strokeLinecap='round'
         strokeLinejoin='round'

--- a/hooks/useReviewLikeQuery.ts
+++ b/hooks/useReviewLikeQuery.ts
@@ -3,6 +3,8 @@ import {
   useMutation,
   useQueryClient,
 } from '@tanstack/react-query';
+import { BookReviewListResponse } from '@/app/reviews/[id]/_lib/getBookReviews';
+import { ReviewDetailResponse } from '@/app/reviews/[id]/_lib/getReviewDetail';
 import { ReviewPageResponse } from '@/app/reviews/_lib/getBestAndPendingReviews';
 import { BookReviewResponse } from '@/app/reviews/_lib/getFilteredBookReviews';
 import { toggleReviewLike } from '@/app/reviews/_lib/toggleReviewLike';
@@ -64,6 +66,37 @@ export const useReviewLikeQuery = (id: number) => {
               }
             }
           }
+          if (queryKey[1] === 'detail') {
+            const value: ReviewDetailResponse | undefined =
+              queryClient.getQueryData(queryKey);
+            if (value && value.bookReview) {
+              const snapshot = { ...value };
+              snapshot.bookReview = {
+                ...snapshot.bookReview,
+                userLikeCk: true,
+                likes: (snapshot.bookReview?.likes || 0) + 1,
+              };
+              queryClient.setQueryData(queryKey, snapshot);
+            }
+          }
+          if (queryKey[1] === 'book') {
+            const value: BookReviewListResponse | undefined =
+              queryClient.getQueryData(queryKey);
+            if (value && value.bookReviews) {
+              const index = value.bookReviews.findIndex((r) => r.id === id);
+
+              if (index > -1) {
+                const snapshot = { ...value };
+                value.bookReviews = [...value.bookReviews];
+                snapshot.bookReviews[index] = {
+                  ...snapshot.bookReviews[index],
+                  userLikeCk: true,
+                  likes: snapshot.bookReviews[index]?.likes + 1,
+                };
+                queryClient.setQueryData(queryKey, snapshot);
+              }
+            }
+          }
         }
       });
     },
@@ -114,6 +147,37 @@ export const useReviewLikeQuery = (id: number) => {
                   ...snapshot.bookReviews[index],
                   userLikeCk: false,
                   likes: snapshot.bookReviews[index].likes - 1,
+                };
+                queryClient.setQueryData(queryKey, snapshot);
+              }
+            }
+          }
+          if (queryKey[1] === 'detail') {
+            const value: ReviewDetailResponse | undefined =
+              queryClient.getQueryData(queryKey);
+            if (value && value.bookReview) {
+              const snapshot = { ...value };
+              snapshot.bookReview = {
+                ...snapshot.bookReview,
+                userLikeCk: false,
+                likes: (snapshot.bookReview?.likes || 0) - 1,
+              };
+              queryClient.setQueryData(queryKey, snapshot);
+            }
+          }
+          if (queryKey[1] === 'book') {
+            const value: BookReviewListResponse | undefined =
+              queryClient.getQueryData(queryKey);
+            if (value && value.bookReviews) {
+              const index = value.bookReviews.findIndex((r) => r.id === id);
+
+              if (index > -1) {
+                const snapshot = { ...value };
+                value.bookReviews = [...value.bookReviews];
+                snapshot.bookReviews[index] = {
+                  ...snapshot.bookReviews[index],
+                  userLikeCk: false,
+                  likes: snapshot.bookReviews[index]?.likes - 1,
                 };
                 queryClient.setQueryData(queryKey, snapshot);
               }
@@ -178,6 +242,37 @@ export const useReviewLikeQuery = (id: number) => {
               }
             }
           }
+          if (queryKey[1] === 'detail') {
+            const value: ReviewDetailResponse | undefined =
+              queryClient.getQueryData(queryKey);
+            if (value && value.bookReview) {
+              const snapshot = { ...value };
+              snapshot.bookReview = {
+                ...snapshot.bookReview,
+                userLikeCk: false,
+                likes: (snapshot.bookReview?.likes || 0) - 1,
+              };
+              queryClient.setQueryData(queryKey, snapshot);
+            }
+          }
+          if (queryKey[1] === 'book') {
+            const value: BookReviewListResponse | undefined =
+              queryClient.getQueryData(queryKey);
+            if (value && value.bookReviews) {
+              const index = value.bookReviews.findIndex((r) => r.id === id);
+
+              if (index > -1) {
+                const snapshot = { ...value };
+                value.bookReviews = [...value.bookReviews];
+                snapshot.bookReviews[index] = {
+                  ...snapshot.bookReviews[index],
+                  userLikeCk: false,
+                  likes: snapshot.bookReviews[index]?.likes - 1,
+                };
+                queryClient.setQueryData(queryKey, snapshot);
+              }
+            }
+          }
         }
       });
     },
@@ -229,6 +324,37 @@ export const useReviewLikeQuery = (id: number) => {
                   ...snapshot.bookReviews[index],
                   userLikeCk: true,
                   likes: snapshot.bookReviews[index].likes + 1,
+                };
+                queryClient.setQueryData(queryKey, snapshot);
+              }
+            }
+          }
+          if (queryKey[1] === 'detail') {
+            const value: ReviewDetailResponse | undefined =
+              queryClient.getQueryData(queryKey);
+            if (value && value.bookReview) {
+              const snapshot = { ...value };
+              snapshot.bookReview = {
+                ...snapshot.bookReview,
+                userLikeCk: true,
+                likes: (snapshot.bookReview?.likes || 0) + 1,
+              };
+              queryClient.setQueryData(queryKey, snapshot);
+            }
+          }
+          if (queryKey[1] === 'book') {
+            const value: BookReviewListResponse | undefined =
+              queryClient.getQueryData(queryKey);
+            if (value && value.bookReviews) {
+              const index = value.bookReviews.findIndex((r) => r.id === id);
+
+              if (index > -1) {
+                const snapshot = { ...value };
+                value.bookReviews = [...value.bookReviews];
+                snapshot.bookReviews[index] = {
+                  ...snapshot.bookReviews[index],
+                  userLikeCk: true,
+                  likes: snapshot.bookReviews[index]?.likes + 1,
                 };
                 queryClient.setQueryData(queryKey, snapshot);
               }

--- a/types/book.ts
+++ b/types/book.ts
@@ -19,15 +19,25 @@ export type PendingBookReview = {
   author: string;
   publisher: string;
   publisherDate: string;
-  start: number;
+  star: number;
   image: string;
   gatheringId: number;
 };
+type BookReviewRating = 'SG' | 'NG' | 'NONE';
+export type BookReviewTag =
+  | 'BAD'
+  | 'CS'
+  | 'DP'
+  | 'FIND'
+  | 'FUN'
+  | 'KL'
+  | 'SAD'
+  | 'TIME';
 export type BookReview = {
   id: number;
-  userId: string;
+  userId: number;
   title: string;
-  apprCd: string;
+  apprCd: BookReviewRating;
   content: string;
   likes: number;
   createTime: string;
@@ -35,4 +45,13 @@ export type BookReview = {
   bookImage: string;
   userLikeCk?: boolean;
   commentCnt?: number;
+};
+export type BookReviewDetail = Omit<BookReview, 'bookImage'> & {
+  bookdId: number;
+  tagCd: string;
+  writerReviewCnt: number;
+  userName: string;
+};
+export type BookDetail = Omit<PendingBookReview, 'gatheringId'> & {
+  gatheringExists?: boolean;
 };

--- a/types/book.ts
+++ b/types/book.ts
@@ -55,3 +55,7 @@ export type BookReviewDetail = Omit<BookReview, 'bookImage'> & {
 export type BookDetail = Omit<PendingBookReview, 'gatheringId'> & {
   gatheringExists?: boolean;
 };
+export type BookReviewByTitle = Omit<
+  BookReview,
+  'apprCd' | 'userName' | 'bookImage'
+>;

--- a/types/review.ts
+++ b/types/review.ts
@@ -6,3 +6,12 @@ export type BookReviewFilter =
   | 'KL'
   | 'TIME'
   | 'FIND';
+export type BookReviewComment = {
+  id: number;
+  userId: number;
+  content: string;
+  orders: number;
+  userName: string;
+  profile: string;
+  createTime: string;
+};


### PR DESCRIPTION
##  🧲 Pull Request

## #️⃣ 연관된 이슈

>  #89 

## 📝 작업 내용
### 구현 기능
- 리뷰 상세 API 연동으로 상세 정보 불러오기
- 동일한 책 이름으로 리뷰 리스트 조회 및 페이지네이션 적용
- 리뷰 상세 페이지에서도 리뷰 좋아요 기능 추가

임의로 리뷰 생성하다가 동일한 리뷰 id가 중복으로 추가된 문제가 있어서
특정 책 리뷰를 불러올 때 우선 key 값에 index로 넣어줬습니다. 나중에 동일한 리뷰 하나 삭제하면 id값으로 변경할 예정입니다. 

## 🔢 리뷰 요구사항 (선택)
> 

## 🖼️ 스크린샷 (선택)
 <img src='https://github.com/user-attachments/assets/ceba505c-58ea-4b26-b5ae-c51343c6a1d2' width='600' />


