### PR TITLE
Feat/manage-meeting 내가 만든 모임 삭제와 찜하기 해제 기능

### DIFF
--- a/app/mypage/meetings/_components/Meeting.tsx
+++ b/app/mypage/meetings/_components/Meeting.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { completeReading } from '../_lib/completeReading';
+import { deleteMeeting } from '../_lib/deleteMeeting';
 import { leaveMeeting } from '../_lib/leaveMeeting';
 import AlertModal from './AlertModal';
 import MeetingDropDown from './MeetingDropDown';
@@ -40,6 +41,14 @@ export default function Meeting({ meeting }: { meeting: MyMeetingList }) {
       });
     },
   });
+  const { mutate: deleteMeetingMutate } = useMutation({
+    mutationFn: (id: number) => deleteMeeting(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['mypage', 'meetings', 'created'],
+      });
+    },
+  });
   const handleComplete = async () => {
     try {
       await completeReading(id);
@@ -53,6 +62,15 @@ export default function Meeting({ meeting }: { meeting: MyMeetingList }) {
         title='참여중인 모임을 나가겠습니까?'
         content='나간 모임은 복구할 수 없습니다.'
         onDelete={() => leaveMeetingMutate(id)}
+      />,
+    );
+  };
+  const handleDelete = () => {
+    openModal(
+      <ConfirmModal
+        title='만든 모임을 삭제하시겠습니까?'
+        content='삭제한 모임은 복구할 수 없습니다.'
+        onDelete={() => deleteMeetingMutate(id)}
       />,
     );
   };
@@ -73,6 +91,7 @@ export default function Meeting({ meeting }: { meeting: MyMeetingList }) {
             tab={tab}
             completeReading={handleComplete}
             leaveMeeting={handleLeave}
+            deleteMeeting={handleDelete}
           />
         </div>
         <div className='flex gap-[2px]'>

--- a/app/mypage/meetings/_components/Meeting.tsx
+++ b/app/mypage/meetings/_components/Meeting.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { completeReading } from '../_lib/completeReading';
 import { deleteMeeting } from '../_lib/deleteMeeting';
 import { leaveMeeting } from '../_lib/leaveMeeting';
+import { unlikeMeeting } from '../_lib/unlikeMeeting';
 import AlertModal from './AlertModal';
 import MeetingDropDown from './MeetingDropDown';
 import { useTabContext } from './TabContext';
@@ -49,6 +50,14 @@ export default function Meeting({ meeting }: { meeting: MyMeetingList }) {
       });
     },
   });
+  const { mutate: unLikeMeetingMutate } = useMutation({
+    mutationFn: (id: number) => unlikeMeeting(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['mypage', 'meetings'],
+      });
+    },
+  });
   const handleComplete = async () => {
     try {
       await completeReading(id);
@@ -74,6 +83,9 @@ export default function Meeting({ meeting }: { meeting: MyMeetingList }) {
       />,
     );
   };
+  const handleUnlike = () => {
+    unLikeMeetingMutate(id);
+  };
   return (
     <div className='w-[696px] flex gap-5 bg-white pt-4 py-7 border-b'>
       <Image
@@ -92,6 +104,7 @@ export default function Meeting({ meeting }: { meeting: MyMeetingList }) {
             completeReading={handleComplete}
             leaveMeeting={handleLeave}
             deleteMeeting={handleDelete}
+            unlikeMeeting={handleUnlike}
           />
         </div>
         <div className='flex gap-[2px]'>

--- a/app/mypage/meetings/_components/Meeting.tsx
+++ b/app/mypage/meetings/_components/Meeting.tsx
@@ -14,6 +14,7 @@ import CalendarIcon from '@/components/common/icons/Calendar';
 import MoreIcon from '@/components/common/icons/MoreIcon';
 import { useModalStore } from '@/store/modal';
 import { MyMeetingList } from '@/types/meeting';
+import { isBefore } from 'date-fns';
 import Image from 'next/image';
 
 export default function Meeting({ meeting }: { meeting: MyMeetingList }) {
@@ -30,6 +31,7 @@ export default function Meeting({ meeting }: { meeting: MyMeetingList }) {
     readingRate,
     userProfiles,
   } = meeting;
+  const isCompleted = isBefore(new Date(endDate), new Date());
   const { mutate: leaveMeetingMutate } = useMutation({
     mutationFn: (id: number) => leaveMeeting(id),
     onSuccess: (data) => {
@@ -86,16 +88,34 @@ export default function Meeting({ meeting }: { meeting: MyMeetingList }) {
   const handleUnlike = () => {
     unLikeMeetingMutate(id);
   };
+  console.log(
+    '완료된 모임인ㅇ지 체크',
+    isBefore(new Date(endDate), new Date()),
+    '모임 끝나는 날짜',
+    new Date(endDate),
+    '현재 날짜',
+    new Date(),
+  );
   return (
     <div className='w-[696px] flex gap-5 bg-white pt-4 py-7 border-b'>
-      <Image
-        src={bookImage}
-        className='w-[113px] h-[170px]'
-        width={113}
-        height={170}
-        alt='책 표지'
-        priority
-      />
+      <div className='relative w-[113px] h-[170px]'>
+        <Image
+          src={bookImage}
+          className='w-[113px] h-[170px]'
+          width={113}
+          height={170}
+          alt='책 표지'
+          priority
+        />
+        {isCompleted && (
+          <>
+            <h4 className='w-1/2 h-16 text-2xl font-bold text-white absolute top-1/4 left-1/4 z-[1]'>
+              모임 종료
+            </h4>
+            <div className='absolute inset-0 bg-[rgba(0,0,0,0.2)]'></div>
+          </>
+        )}
+      </div>
       <div className='w-3/4 text-sm'>
         <div className='flex justify-between'>
           <h3 className='text-lg text-customGrey-800 font-bold mb-2'>{name}</h3>
@@ -147,9 +167,7 @@ export default function Meeting({ meeting }: { meeting: MyMeetingList }) {
             </div>
           </div>
           <p className='text-sm text-customGreen-500'>
-            {currentCapacity}명과 함께{' '}
-            {/* TODO (유진) 만든 모임에서도 완료한 모임 여부 판단 추가할 예정 */}
-            {tab === 'completed' ? '읽었어요' : '읽는 중'}
+            {currentCapacity}명과 함께 {isCompleted ? '읽었어요' : '읽는 중'}
           </p>
         </div>
       </div>

--- a/app/mypage/meetings/_components/MeetingDropDown.tsx
+++ b/app/mypage/meetings/_components/MeetingDropDown.tsx
@@ -5,12 +5,14 @@ type Props = {
   completeReading: () => void;
   leaveMeeting: () => void;
   deleteMeeting: () => void;
+  unlikeMeeting: () => void;
 };
 export default function MeetingDropDown({
   tab,
   completeReading,
   leaveMeeting,
   deleteMeeting,
+  unlikeMeeting,
 }: Props) {
   if (tab === 'completed') return null;
   if (tab === 'active') {
@@ -27,6 +29,15 @@ export default function MeetingDropDown({
     return (
       <DropDown
         items={[{ text: '삭제하기', onClick: deleteMeeting, isDelete: true }]}
+      />
+    );
+  }
+  if (tab === 'bookmark') {
+    return (
+      <DropDown
+        items={[
+          { text: '찜하기 해제', onClick: unlikeMeeting, isDelete: true },
+        ]}
       />
     );
   }

--- a/app/mypage/meetings/_components/MeetingDropDown.tsx
+++ b/app/mypage/meetings/_components/MeetingDropDown.tsx
@@ -4,11 +4,13 @@ type Props = {
   tab: 'active' | 'completed' | 'created' | 'bookmark';
   completeReading: () => void;
   leaveMeeting: () => void;
+  deleteMeeting: () => void;
 };
 export default function MeetingDropDown({
   tab,
   completeReading,
   leaveMeeting,
+  deleteMeeting,
 }: Props) {
   if (tab === 'completed') return null;
   if (tab === 'active') {
@@ -18,6 +20,13 @@ export default function MeetingDropDown({
           { text: '독서 완료하기', onClick: completeReading },
           { text: '모임 나가기', onClick: leaveMeeting, isDelete: true },
         ]}
+      />
+    );
+  }
+  if (tab === 'created') {
+    return (
+      <DropDown
+        items={[{ text: '삭제하기', onClick: deleteMeeting, isDelete: true }]}
       />
     );
   }

--- a/app/mypage/meetings/_lib/deleteMeeting.ts
+++ b/app/mypage/meetings/_lib/deleteMeeting.ts
@@ -1,0 +1,5 @@
+import { fetchAPIClient } from '@/lib/fetchAPI.client';
+
+export const deleteMeeting = async (id: number) => {
+  return await fetchAPIClient(`/api/gathering/${id}`, 'DELETE');
+};

--- a/app/mypage/meetings/_lib/mymeetings.ts
+++ b/app/mypage/meetings/_lib/mymeetings.ts
@@ -7,7 +7,7 @@ export const getActiveMeetings = async (page: number, size: number) => {
     'GET',
   );
   if (res.code === 'SUCCESS') {
-    return res.result.gatheringResponses as MyMeetingList[];
+    return (res.result.gatheringResponses as MyMeetingList[]) || [];
   }
   throw new Error(`Failed fetch active meetings ${res.code}-${res.message}`);
 };
@@ -18,7 +18,7 @@ export const getCompletedMeetings = async (page: number, size: number) => {
     'GET',
   );
   if (res.code === 'SUCCESS') {
-    return res.result.gatheringResponses as MyMeetingList[];
+    return (res.result.gatheringResponses as MyMeetingList[]) || [];
   }
   throw new Error(`Failed fetch active meetings ${res.code}-${res.message}`);
 };
@@ -28,7 +28,7 @@ export const getMeetingCounts = async () => {
   if (res.code === 'SUCCESS') {
     return res.result as MyMeetingCount;
   }
-  throw new Error(`Failed fetch meeting counts ${res.code}-${res.message}`);
+  throw new Error('Failed fetch meeting counts');
 };
 export const getCreatedMeetings = async (page: number, size: number) => {
   const res = await fetchAPIClient(
@@ -36,9 +36,9 @@ export const getCreatedMeetings = async (page: number, size: number) => {
     'GET',
   );
   if (res.code === 'SUCCESS') {
-    return res.result.gatheringResponses as MyMeetingList[];
+    return (res.result.gatheringResponses as MyMeetingList[]) || [];
   }
-  throw new Error(`Failed fetch meeting counts ${res.code}-${res.message}`);
+  throw new Error('Failed fetch meeting counts');
 };
 export const getBookmarkedMeetings = async (page: number, size: number) => {
   const res = await fetchAPIClient(
@@ -46,7 +46,7 @@ export const getBookmarkedMeetings = async (page: number, size: number) => {
     'GET',
   );
   if (res.code === 'SUCCESS') {
-    return res.result.gatheringResponses as MyMeetingList[];
+    return (res.result.gatheringResponses as MyMeetingList[]) || [];
   }
-  throw new Error(`Failed fetch meeting counts ${res.code}-${res.message}`);
+  throw new Error('Failed fetch meeting counts');
 };

--- a/app/mypage/meetings/_lib/unlikeMeeting.ts
+++ b/app/mypage/meetings/_lib/unlikeMeeting.ts
@@ -1,0 +1,5 @@
+import { fetchAPIClient } from '@/lib/fetchAPI.client';
+
+export const unlikeMeeting = async (id: number) => {
+  return await fetchAPIClient(`/api/gathering/${id}/wish`, 'POST');
+};


### PR DESCRIPTION
##  🧲 Pull Request

## #️⃣ 연관된 이슈

#133 

## 📝 작업 내용
1. 내가 만든 모임 삭제 시, 삭제 확인 모달 후 만든 모임 삭제
2. 모임 찜하기 해제도 가능합니다. 낙관적 업데이트로 하려다 나의 모임에서는 하트를 보여주는 부분이 없어서 일단 급하게
쿼리 키 무효화로 진행했습니다. 
3. 완료된 모임의 경우 endDate를 기준으로 '모임 종료' 표시와 '~함께 읽었어요'라고 수정했습니다. 

## 🔢 리뷰 요구사항 (선택)
이전에 만들었던 모임의 경우, endDate가 잘못 설정되어 있어서 저희 시연 영상 찍을 때는 모임 데이터 다시 싹 갈아서 
만들어야 할 것 같습니다. 

## 🖼️ 스크린샷 (선택)
<img src='https://github.com/user-attachments/assets/9ec45f27-ea94-45b8-b84e-4d7807e93e85' width='400'/>
<p>완료된 모임의 경우 UI </p>
👉 옛날 모임 데이터가 endDate가 모집 마감일로 설정되어 있어 현재 참여 중인 모임에서 모집 완료라고 보이는 부분이라
좀이따 모임 데이터를 싹 바꿔야할 것 같습니다. 
