### PR TITLE
Fix/my-meeting 참여중인 모임 조회 요청 주소 변경

### DIFF
--- a/app/mypage/meetings/_lib/mymeetings.ts
+++ b/app/mypage/meetings/_lib/mymeetings.ts
@@ -3,7 +3,7 @@ import { MyMeetingCount, MyMeetingList } from '@/types/meeting';
 
 export const getActiveMeetings = async (page: number, size: number) => {
   const res = await fetchAPIClient(
-    `/api/gatheringSearch/participating?page=${page}&size=${size}&gatheringStatus=ACTIVE&gatheringUserStatus=PARTICIPATING`,
+    `/api/gatheringSearch/participating?page=${page}&size=${size}&gatheringUserStatus=PARTICIPATING`,
     'GET',
   );
   if (res.code === 'SUCCESS') {


### PR DESCRIPTION
##  🧲 Pull Request

## #️⃣ 연관된 이슈
 #143 

## 📝 작업 내용
마이페이지 나의 모임에서 참여 중인 모임 조회가 잘 안되는 문제가 있어 요청 주소를 변경했습니다. 
백엔드 분한테 여쭤보니 
현재 챌린지 시작된 모임 ->  gatheringStatus = ACTIVE
챌린지 시작 안된 모집중인 모임 -> gatheringStatus = RECRUITING 로 구분된다고 말씀해주셨습니다. 

## 🔢 리뷰 요구사항 (선택)


## 🖼️ 스크린샷 (선택)

